### PR TITLE
fixing name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![tests](https://github.com/insipx/desub/workflows/Rust/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/paritytech/desub/badge.svg?branch=master&service=github)](https://coveralls.io/github/paritytech/desub?branch=master&service=github)
-# De[code] [S]ubstrate
+# De[code] Sub[strate]
 
 <sub><sup>† This software is experimental, and not intended for production use yet. Use at your own risk.
 


### PR DESCRIPTION
`De[code] [S]ubstrate` doesn't explain at all the `desub` term... it would either `de-ubstrate` or `codeS` ... I think you meant to do `De[code] Sub[strate]`, no?