### PR TITLE
remove backtrace feature

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-desub.  If not, see <http://www.gnu.org/licenses/>.
 
-#![feature(backtrace)]
-
 #[forbid(unsafe_code)]
 pub mod decoder;
 mod error;


### PR DESCRIPTION

Left this in from a previous PR while testing some extrinsics, causes CI to fail to build on stable rust