### PR TITLE
Fix some warnings and arrange cargo.toml

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,6 +3,7 @@ name = "desub-core"
 version = "0.0.1"
 authors = [ "Andrew Plaza <andrew.plaza@parity.io>" ]
 edition = "2018"
+repository = "https://github.com/paritytech/desub"
 
 [dependencies]
 log = "0.4"

--- a/extras/Cargo.toml
+++ b/extras/Cargo.toml
@@ -3,6 +3,7 @@ name = "desub-extras"
 version = "0.0.1"
 authors = [ "Andrew Plaza <andrew.plaza@parity.io>" ]
 edition = "2018"
+repository = "https://github.com/paritytech/desub"
 
 
 [dependencies]

--- a/extras/src/extrinsics.rs
+++ b/extras/src/extrinsics.rs
@@ -66,6 +66,6 @@ mod tests {
 
 	#[test]
 	fn should_deserialize_extrinsics() {
-		let extrinsics: Extrinsics = Extrinsics::new(TEST_STR).unwrap();
+		let _extrinsics: Extrinsics = Extrinsics::new(TEST_STR).unwrap();
 	}
 }

--- a/extras/src/modules.rs
+++ b/extras/src/modules.rs
@@ -230,7 +230,7 @@ fn parse_enum(obj: &serde_json::Value) -> RustTypeMarker {
 #[cfg(test)]
 mod tests {
 	use super::Modules;
-	use super::*;
+
 	use crate::error::Error;
 	use crate::ModuleTypes;
 	use core::{EnumField, RustTypeMarker, SetField, StructField, StructUnitOrTuple};

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 authors = ["Andrew Plaza <andrew.plaza@parity.io>"]
 edition = "2018"
 autotests = false
-
+repository = "https://github.com/paritytech/desub"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
+[dev-dependencies]
 desub-core = { path = "../core", package = "desub-core" }
 extras = { path = "../extras", package = "desub-extras" }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
I think the `extras` crate is better to be merged into` core`, it's not a complex function for  `extras`,  we don't need to use two crates.

And the defintions json is not apposite to be included in crates. People use `extras` crate should import them by theirself.