### PR TITLE
Parse signed payload and expose call data type information

### DIFF
--- a/bin/tx-decoder/src/decoder.rs
+++ b/bin/tx-decoder/src/decoder.rs
@@ -46,11 +46,11 @@ impl Decoder {
 	}
 
 	// Decodes extrinsics and serializes to String
-	pub fn decode_extrinsics(&self, version: SpecVersion, data: &[u8]) -> Result<String, Error> {
+	pub fn decode_extrinsics(&self, version: SpecVersion, mut data: &[u8]) -> Result<String, Error> {
 		if self.is_version_new(version) {
 			log::debug!("DECODING NEW");
 			let decoder = self.new.get(&version.try_into()?).ok_or_else(|| anyhow!("version {} not found for new decoder", version))?;
-			match decoder.decode_extrinsics(data) {
+			match decoder.decode_extrinsics(&mut data) {
 				Ok(v) => Ok(format!("{:#?}", v)),
 				Err(e) => Err(e.1.into())
 			}

--- a/bin/v14-test/src/main.rs
+++ b/bin/v14-test/src/main.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), anyhow::Error> {
 		Err(e) => anyhow::bail!("Cannot decode hex string into bytes: {}", e),
 	};
 
-	let decoded = match decoder.decode_extrinsic(&bytes) {
+	let decoded = match decoder.decode_extrinsic(&mut &*bytes) {
 		Ok(decoded) => decoded,
 		Err(e) => anyhow::bail!("Cannot decode extrinsic: {}", e),
 	};

--- a/core_v14/src/decoder/decode_type.rs
+++ b/core_v14/src/decoder/decode_type.rs
@@ -14,15 +14,19 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-desub.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{
-	metadata::{Type, TypeDef, TypeId},
-	value::{BitSequence, Composite, Primitive, Value, Variant},
-};
+use crate::value::{BitSequence, Composite, Primitive, Value, Variant};
 use codec::{Compact, Decode};
 use scale_info::{
 	form::PortableForm, Field, PortableRegistry, TypeDefArray, TypeDefBitSequence, TypeDefCompact, TypeDefComposite,
 	TypeDefPrimitive, TypeDefSequence, TypeDefTuple, TypeDefVariant,
 };
+
+// Some type aliases used below. `scale-info` is re-exported at the root,
+// so to avoid confusion we only publically export all scale-info types from that
+// one place.
+type TypeDef = scale_info::TypeDef<PortableForm>;
+type Type = scale_info::Type<PortableForm>;
+type TypeId = <scale_info::form::PortableForm as scale_info::form::Form>::Type;
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum DecodeTypeError {

--- a/core_v14/src/decoder/extrinsic_bytes.rs
+++ b/core_v14/src/decoder/extrinsic_bytes.rs
@@ -60,7 +60,7 @@ pub struct ExtrinsicBytesIter<'a> {
 	cursor: usize,
 }
 
-impl <'a> ExtrinsicBytesIter<'a> {
+impl<'a> ExtrinsicBytesIter<'a> {
 	/// Return the number of bytes remaining. If an iteration resulted in an error,
 	/// we'll return the bytes that we failed to decode, too.
 	pub fn remaining_bytes(&self) -> &'a [u8] {

--- a/core_v14/src/decoder/mod.rs
+++ b/core_v14/src/decoder/mod.rs
@@ -44,8 +44,8 @@ let extrinsics = decoder.decode_extrinsics(extrinsics_cursor).unwrap();
 assert_eq!(extrinsics_cursor.len(), 0);
 assert_eq!(extrinsics.len(), 3);
 for ext in extrinsics {
-	assert_eq!(ext.call_data.pallet_name, "Auctions");
-	assert_eq!(&*ext.call_data.ty.name(), "bid");
+    assert_eq!(ext.call_data.pallet_name, "Auctions");
+    assert_eq!(&*ext.call_data.ty.name(), "bid");
 }
 ```
 
@@ -168,7 +168,7 @@ impl Decoder {
 
 		let mut out = Vec::with_capacity(extrinsic_bytes.len());
 		let mut extrinsics_iter = extrinsic_bytes.iter();
-		while let Some(res) = extrinsics_iter.next() {
+		for res in &mut extrinsics_iter {
 			let single_extrinsic = match res {
 				Ok(bytes) => bytes,
 				Err(e) => return Err((out, e.into())),
@@ -281,7 +281,7 @@ impl Decoder {
 		let mut arguments = vec![];
 		for field in variant.fields() {
 			let type_id = field.ty().id();
-			let ty = self.metadata.types().resolve(type_id).ok_or_else(|| DecodeError::CannotFindType(type_id))?;
+			let ty = self.metadata.types().resolve(type_id).ok_or(DecodeError::CannotFindType(type_id))?;
 			let val = match decode_type(data, ty, self.metadata.types()) {
 				Ok(val) => val,
 				Err(err) => return Err(err.into()),

--- a/core_v14/src/decoder/mod.rs
+++ b/core_v14/src/decoder/mod.rs
@@ -44,8 +44,8 @@ let extrinsics = decoder.decode_extrinsics(extrinsics_cursor).unwrap();
 assert_eq!(extrinsics_cursor.len(), 0);
 assert_eq!(extrinsics.len(), 3);
 for ext in extrinsics {
-    assert_eq!(ext.call_data.pallet_name, "Auctions");
-    assert_eq!(&*ext.call_data.ty.name(), "bid");
+	assert_eq!(ext.call_data.pallet_name, "Auctions");
+	assert_eq!(&*ext.call_data.ty.name(), "bid");
 }
 ```
 
@@ -110,7 +110,7 @@ assert_eq!(&*extrinsic.call_data.ty.name(), "bid");
 mod decode_type;
 mod extrinsic_bytes;
 
-use crate::metadata::{ self, Metadata };
+use crate::metadata::{self, Metadata};
 use crate::value::Value;
 use codec::{Compact, Decode};
 use decode_type::{decode_type, decode_type_by_id, DecodeTypeError};
@@ -158,7 +158,10 @@ impl Decoder {
 	/// expected to be provided in a SCALE-encoded form equivalent to `Vec<(Compact<u32>,Extrinsic)>`; in other words, we
 	/// start with a compact encoded count of how many extrinsics exist, and then each extrinsic is prefixed by
 	/// a compact encoding of its byte length.
-	pub fn decode_extrinsics<'a>(&'a self, data: &mut &[u8]) -> Result<Vec<Extrinsic<'a>>, (Vec<Extrinsic<'a>>, DecodeError)> {
+	pub fn decode_extrinsics<'a>(
+		&'a self,
+		data: &mut &[u8],
+	) -> Result<Vec<Extrinsic<'a>>, (Vec<Extrinsic<'a>>, DecodeError)> {
 		let extrinsic_bytes = AllExtrinsicBytes::new(*data).map_err(|e| (Vec::new(), e.into()))?;
 
 		log::trace!("Decoding {} Total Extrinsics.", extrinsic_bytes.len());
@@ -202,7 +205,6 @@ impl Decoder {
 	/// If your extrinsic is not prefixed by its byte length, use [`Decoder::decode_unwrapped_extrinsic`] to
 	/// decode it instead.
 	pub fn decode_extrinsic<'a>(&'a self, data: &mut &[u8]) -> Result<Extrinsic<'a>, DecodeError> {
-
 		// Ignore the expected extrinsic length here at the moment, since `decode_unwrapped_extrinsic` will
 		// error accordingly if the wrong number of bytes are consumed.
 		let _len = <Compact<u32>>::decode(data)?;
@@ -254,10 +256,7 @@ impl Decoder {
 		// Finally, decode the call data.
 		let call_data = self.decode_call_data(data)?;
 
-		Ok(Extrinsic {
-			call_data,
-			signature,
-		})
+		Ok(Extrinsic { call_data, signature })
 	}
 
 	/// Decode SCALE encoded call data. Conceptually, this is expected to take the form of
@@ -290,11 +289,7 @@ impl Decoder {
 			arguments.push(val);
 		}
 
-		Ok(CallData {
-			pallet_name,
-			ty: variant,
-			arguments
-		})
+		Ok(CallData { pallet_name, ty: variant, arguments })
 	}
 
 	/// Decode the SCALE encoded data that you would get signed, which conceptually takes the form
@@ -306,15 +301,10 @@ impl Decoder {
 		let extensions = signed_extensions
 			.into_iter()
 			.zip(additional_signed)
-			.map(|((name, extension), (_, additional))| {
-				(name, SignedExtensionWithAdditional { additional, extension })
-			})
+			.map(|((name, extension), (_, additional))| (name, SignedExtensionWithAdditional { additional, extension }))
 			.collect();
 
-		Ok(SignerPayload {
-			call_data,
-			extensions
-		})
+		Ok(SignerPayload { call_data, extensions })
 	}
 
 	/// Decode a SCALE encoded extrinsic signature.
@@ -327,7 +317,7 @@ impl Decoder {
 	}
 
 	/// Decode the signed extensions.
-	fn decode_signed_extensions<'a>(&'a self, data: &mut &[u8]) -> Result<Vec<(&'a str,Value)>, DecodeError> {
+	fn decode_signed_extensions<'a>(&'a self, data: &mut &[u8]) -> Result<Vec<(&'a str, Value)>, DecodeError> {
 		self.metadata
 			.extrinsic()
 			.signed_extensions()
@@ -342,7 +332,7 @@ impl Decoder {
 
 	/// Decode the additional signed data. This isn't used for decoding extrinsics, but instead for
 	/// decoding the data that you'd sign.
-	fn decode_additional_signed<'a>(&'a self, data: &mut &[u8]) -> Result<Vec<(&'a str,Value)>, DecodeError> {
+	fn decode_additional_signed<'a>(&'a self, data: &mut &[u8]) -> Result<Vec<(&'a str, Value)>, DecodeError> {
 		self.metadata
 			.extrinsic()
 			.signed_extensions()
@@ -365,7 +355,7 @@ pub struct CallData<'a> {
 	/// of the call and information about each argument)
 	pub ty: &'a metadata::Variant,
 	/// The decoded argument data
-	pub arguments: Vec<Value>
+	pub arguments: Vec<Value>,
 }
 
 /// Decoded call data and associated type information.
@@ -377,16 +367,12 @@ pub struct CallDataOwned {
 	/// of the call and information about each argument)
 	pub ty: metadata::Variant,
 	/// The decoded argument data
-	pub arguments: Vec<Value>
+	pub arguments: Vec<Value>,
 }
 
-impl <'a> CallData<'a> {
+impl<'a> CallData<'a> {
 	pub fn into_owned(self) -> CallDataOwned {
-		CallDataOwned {
-			pallet_name: self.pallet_name.to_owned(),
-			ty: self.ty.clone(),
-			arguments: self.arguments
-		}
+		CallDataOwned { pallet_name: self.pallet_name.to_owned(), ty: self.ty.clone(), arguments: self.arguments }
 	}
 }
 
@@ -408,12 +394,9 @@ pub struct ExtrinsicOwned {
 	pub signature: Option<ExtrinsicSignatureOwned>,
 }
 
-impl <'a> Extrinsic<'a> {
+impl<'a> Extrinsic<'a> {
 	pub fn into_owned(self) -> ExtrinsicOwned {
-		ExtrinsicOwned {
-			call_data: self.call_data.into_owned(),
-			signature: self.signature.map(|s| s.into_owned())
-		}
+		ExtrinsicOwned { call_data: self.call_data.into_owned(), signature: self.signature.map(|s| s.into_owned()) }
 	}
 }
 
@@ -441,15 +424,12 @@ pub struct ExtrinsicSignatureOwned {
 	pub extensions: Vec<(String, Value)>,
 }
 
-impl <'a> ExtrinsicSignature<'a> {
+impl<'a> ExtrinsicSignature<'a> {
 	pub fn into_owned(self) -> ExtrinsicSignatureOwned {
 		ExtrinsicSignatureOwned {
 			address: self.address,
 			signature: self.signature,
-			extensions: self.extensions
-				.into_iter()
-				.map(|(k,v)| (k.to_owned(), v))
-				.collect()
+			extensions: self.extensions.into_iter().map(|(k, v)| (k.to_owned(), v)).collect(),
 		}
 	}
 }
@@ -474,14 +454,11 @@ pub struct SignerPayloadOwned {
 	pub extensions: Vec<(String, SignedExtensionWithAdditional)>,
 }
 
-impl <'a> SignerPayload<'a> {
+impl<'a> SignerPayload<'a> {
 	pub fn into_owned(self) -> SignerPayloadOwned {
 		SignerPayloadOwned {
 			call_data: self.call_data.into_owned(),
-			extensions: self.extensions
-				.into_iter()
-				.map(|(k,v)| (k.to_owned(), v))
-				.collect()
+			extensions: self.extensions.into_iter().map(|(k, v)| (k.to_owned(), v)).collect(),
 		}
 	}
 }

--- a/core_v14/src/decoder/mod.rs
+++ b/core_v14/src/decoder/mod.rs
@@ -43,10 +43,6 @@ let extrinsics = decoder.decode_extrinsics(extrinsics_cursor).unwrap();
 
 assert_eq!(extrinsics_cursor.len(), 0);
 assert_eq!(extrinsics.len(), 3);
-for ext in extrinsics {
-	assert_eq!(ext.call_data.pallet_name, "Auctions");
-	assert_eq!(&*ext.call_data.ty.name(), "bid");
-}
 ```
 
 ## Decoding a single extrinsic

--- a/core_v14/src/decoder/mod.rs
+++ b/core_v14/src/decoder/mod.rs
@@ -44,8 +44,8 @@ let extrinsics = decoder.decode_extrinsics(extrinsics_cursor).unwrap();
 assert_eq!(extrinsics_cursor.len(), 0);
 assert_eq!(extrinsics.len(), 3);
 for ext in extrinsics {
-    assert_eq!(ext.call_data.pallet_name, "Auctions");
-    assert_eq!(&*ext.call_data.ty.name(), "bid");
+	assert_eq!(ext.call_data.pallet_name, "Auctions");
+	assert_eq!(&*ext.call_data.ty.name(), "bid");
 }
 ```
 
@@ -110,7 +110,7 @@ assert_eq!(&*extrinsic.call_data.ty.name(), "bid");
 mod decode_type;
 mod extrinsic_bytes;
 
-use crate::metadata::{self, Metadata};
+use crate::metadata::Metadata;
 use crate::value::Value;
 use codec::{Compact, Decode};
 use decode_type::{decode_type, decode_type_by_id, DecodeTypeError};
@@ -353,7 +353,7 @@ pub struct CallData<'a> {
 	pub pallet_name: &'a str,
 	/// The type information for this call (including the name
 	/// of the call and information about each argument)
-	pub ty: &'a metadata::Variant,
+	pub ty: &'a scale_info::Variant<scale_info::form::PortableForm>,
 	/// The decoded argument data
 	pub arguments: Vec<Value>,
 }
@@ -365,7 +365,7 @@ pub struct CallDataOwned {
 	pub pallet_name: String,
 	/// The type information for this call (including the name
 	/// of the call and information about each argument)
-	pub ty: metadata::Variant,
+	pub ty: scale_info::Variant<scale_info::form::PortableForm>,
 	/// The decoded argument data
 	pub arguments: Vec<Value>,
 }

--- a/core_v14/src/decoder/mod.rs
+++ b/core_v14/src/decoder/mod.rs
@@ -131,7 +131,7 @@ pub enum DecodeError {
 	#[error("Failed to decode: expected more data")]
 	EarlyEof(&'static str),
 	#[error("Failed to decode extrinsics: {0} bytes of the input were not consumed")]
-	DidntConsumeBytes(usize),
+	ExcessBytes(usize),
 	#[error("Failed to decode unsupported extrinsic version '{0}'")]
 	CannotDecodeExtrinsicVersion(u8),
 	#[error("Cannot find call corresponding to extrinsic with pallet index {0} and call index {1}")]
@@ -182,7 +182,7 @@ impl Decoder {
 			// If decoding didn't consume all extrinsic bytes, something went wrong.
 			// Hand back whatever we have but note the error.
 			if !bytes.is_empty() {
-				return Err((out, DecodeError::DidntConsumeBytes(bytes.len())));
+				return Err((out, DecodeError::ExcessBytes(bytes.len())));
 			}
 
 			out.push(ext);

--- a/core_v14/src/decoder/mod.rs
+++ b/core_v14/src/decoder/mod.rs
@@ -130,7 +130,7 @@ pub enum DecodeError {
 	DecodeTypeError(#[from] DecodeTypeError),
 	#[error("Failed to decode: expected more data")]
 	EarlyEof(&'static str),
-	#[error("Failed to decode extrinsics: expected {0} more bytes to be consumed from the input")]
+	#[error("Failed to decode extrinsics: {0} bytes of the input were not consumed")]
 	DidntConsumeBytes(usize),
 	#[error("Failed to decode unsupported extrinsic version '{0}'")]
 	CannotDecodeExtrinsicVersion(u8),
@@ -288,7 +288,7 @@ impl Decoder {
 		Ok(CallData { pallet_name: Cow::Borrowed(pallet_name), ty: Cow::Borrowed(variant), arguments })
 	}
 
-	/// Decode the SCALE encoded data that you would get signed, which conceptually takes the form
+	/// Decode the SCALE encoded data that, once signed, is used to construct a signed extrinsic. The encoded payload has the following shape:
 	/// `(call_data, signed_extensions, additional_signed)`.
 	pub fn decode_signer_payload<'a>(&'a self, data: &mut &[u8]) -> Result<SignerPayload<'a>, DecodeError> {
 		let call_data = self.decode_call_data(data)?;
@@ -327,7 +327,7 @@ impl Decoder {
 	}
 
 	/// Decode the additional signed data. This isn't used for decoding extrinsics, but instead for
-	/// decoding the data that you'd sign.
+	/// decoding the data that a user signs.
 	fn decode_additional_signed<'a>(&'a self, data: &mut &[u8]) -> Result<Vec<(Cow<'a, str>, Value)>, DecodeError> {
 		self.metadata
 			.extrinsic()

--- a/core_v14/src/lib.rs
+++ b/core_v14/src/lib.rs
@@ -21,3 +21,6 @@ pub mod value;
 pub use decoder::Decoder;
 pub use metadata::Metadata;
 pub use value::Value;
+
+/// A re-export of the [`scale_info`] crate, since we delegate much of the type inspection to it.
+pub use scale_info;

--- a/core_v14/src/metadata/mod.rs
+++ b/core_v14/src/metadata/mod.rs
@@ -27,7 +27,7 @@ use scale_info::{form::PortableForm, PortableRegistry};
 use std::collections::HashMap;
 
 // Some type aliases used below. `scale-info` is re-exported at the root,
-// so to avoid confusion we only publically export all scale-info types from that
+// so to avoid confusion we only publicly export all scale-info types from that
 // one place.
 type TypeId = <scale_info::form::PortableForm as scale_info::form::Form>::Type;
 type TypeDefVariant = scale_info::TypeDefVariant<PortableForm>;
@@ -98,7 +98,7 @@ impl Metadata {
 	}
 
 	/// Given the `u8` variant index of a pallet and call, this returns the pallet name and the call Variant
-	/// if found, or `None` if it no such call exists at those indexes, or we don't have suitable call data.
+	/// if found, or `None` if no such call exists at those indexes, or we don't have suitable call data.
 	pub(crate) fn call_variant_by_enum_index(
 		&self,
 		pallet: u8,

--- a/core_v14/src/metadata/mod.rs
+++ b/core_v14/src/metadata/mod.rs
@@ -115,14 +115,11 @@ impl Metadata {
 
 	/// A helper function to get hold of a Variant given a type ID, or None if it's not found.
 	fn get_variant(&self, ty: TypeId) -> Option<&TypeDefVariant> {
-		self.types.resolve(ty.id()).and_then(|ty| {
-			match ty.type_def() {
-				scale_info::TypeDef::Variant(variant) => Some(variant),
-				_ => None
-			}
+		self.types.resolve(ty.id()).and_then(|ty| match ty.type_def() {
+			scale_info::TypeDef::Variant(variant) => Some(variant),
+			_ => None,
 		})
 	}
-
 }
 
 /// Get the decoded metadata version. At some point `RuntimeMetadataPrefixed` will end up

--- a/core_v14/src/metadata/version_14.rs
+++ b/core_v14/src/metadata/version_14.rs
@@ -32,8 +32,6 @@ pub fn decode(meta: RuntimeMetadataV14) -> Result<Metadata, MetadataError> {
 		let calls = pallet
 			.calls
 			.map(|call_md| {
-				let mut call_variant_indexes = HashMap::new();
-
 				// Get the type representing the variant of available calls:
 				let calls_type_id = call_md.ty;
 				let calls_type = registry
@@ -50,9 +48,12 @@ pub fn decode(meta: RuntimeMetadataV14) -> Result<Metadata, MetadataError> {
 				};
 
 				// Store the mapping from u8 index to variant slice index or quicker decode lookup:
-				for (idx, variant) in calls_variant.variants().iter().enumerate() {
-					call_variant_indexes.insert(variant.index(), idx);
-				}
+				let call_variant_indexes = calls_variant
+					.variants()
+					.iter()
+					.enumerate()
+					.map(|(idx, v)| (v.index(), idx))
+					.collect();
 
 				Ok(MetadataCalls { calls_type_id, call_variant_indexes })
 			})

--- a/core_v14/src/metadata/version_14.rs
+++ b/core_v14/src/metadata/version_14.rs
@@ -36,8 +36,9 @@ pub fn decode(meta: RuntimeMetadataV14) -> Result<Metadata, MetadataError> {
 
 				// Get the type representing the variant of available calls:
 				let calls_type_id = call_md.ty;
-				let calls_type =
-					registry.resolve(calls_type_id.id()).ok_or_else(|| MetadataError::TypeNotFound(calls_type_id.id()))?;
+				let calls_type = registry
+					.resolve(calls_type_id.id())
+					.ok_or_else(|| MetadataError::TypeNotFound(calls_type_id.id()))?;
 
 				// Expect that type to be a variant:
 				let calls_type_def = calls_type.type_def();

--- a/core_v14/src/metadata/version_14.rs
+++ b/core_v14/src/metadata/version_14.rs
@@ -47,7 +47,7 @@ pub fn decode(meta: RuntimeMetadataV14) -> Result<Metadata, MetadataError> {
 					}
 				};
 
-				// Store the mapping from u8 index to variant slice index or quicker decode lookup:
+				// Store the mapping from u8 index to variant slice index for quicker decode lookup:
 				let call_variant_indexes = calls_variant
 					.variants()
 					.iter()

--- a/core_v14/src/metadata/version_14.rs
+++ b/core_v14/src/metadata/version_14.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-desub.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::{Metadata, MetadataCall, MetadataError, MetadataExtrinsic, MetadataPallet};
+use super::{Metadata, MetadataCalls, MetadataError, MetadataExtrinsic, MetadataPallet};
 use frame_metadata::RuntimeMetadataV14;
 use std::collections::HashMap;
 
@@ -29,32 +29,37 @@ pub fn decode(meta: RuntimeMetadataV14) -> Result<Metadata, MetadataError> {
 
 	// Gather information about the pallets in use:
 	for pallet in meta.pallets {
-		let mut calls = HashMap::new();
-		if let Some(call_md) = pallet.calls {
+		let calls = pallet.calls.map(|call_md| {
+			let mut call_variant_indexes = HashMap::new();
+
 			// Get the type representing the variant of available calls:
-			let call_ty_id = call_md.ty.id();
-			let call_ty = registry.resolve(call_ty_id).ok_or(MetadataError::TypeNotFound(call_ty_id))?;
+			let calls_type_id = call_md.ty;
+			let calls_type = registry.resolve(calls_type_id.id()).ok_or(MetadataError::TypeNotFound(calls_type_id.id()))?;
 
 			// Expect that type to be a variant:
-			let call_ty_def = call_ty.type_def();
-			let call_variant = match call_ty_def {
+			let calls_type_def = calls_type.type_def();
+			let calls_variant = match calls_type_def {
 				scale_info::TypeDef::Variant(variant) => variant,
 				_ => {
-					return Err(MetadataError::ExpectedVariantType { got: format!("{:?}", call_ty_def) });
+					return Err(MetadataError::ExpectedVariantType { got: format!("{:?}", calls_type_def) });
 				}
 			};
 
-			// Treat each variant as a function call and push to our calls list
-			for variant in call_variant.variants() {
-				// Allow case insensitive matching; lowercase the name:
-				let name = variant.name().to_ascii_lowercase();
-				let args = variant.fields().iter().map(|field| *field.ty()).collect();
-
-				calls.insert(variant.index(), MetadataCall { name, args });
+			// Store the mapping from u8 index to variant slice index or quicker decode lookup:
+			for (idx, variant) in calls_variant.variants().iter().enumerate() {
+				call_variant_indexes.insert(variant.index(), idx);
 			}
-		}
 
-		pallets.insert(pallet.index, MetadataPallet { name: pallet.name, calls });
+			Ok(MetadataCalls {
+				calls_type_id,
+				call_variant_indexes
+			})
+		}).transpose()?;
+
+		pallets.insert(pallet.index, MetadataPallet {
+			name: pallet.name,
+			calls
+		});
 	}
 
 	Ok(Metadata { pallets, extrinsic, types: registry })

--- a/core_v14/src/metadata/version_14.rs
+++ b/core_v14/src/metadata/version_14.rs
@@ -37,7 +37,7 @@ pub fn decode(meta: RuntimeMetadataV14) -> Result<Metadata, MetadataError> {
 				// Get the type representing the variant of available calls:
 				let calls_type_id = call_md.ty;
 				let calls_type =
-					registry.resolve(calls_type_id.id()).ok_or(MetadataError::TypeNotFound(calls_type_id.id()))?;
+					registry.resolve(calls_type_id.id()).ok_or_else(|| MetadataError::TypeNotFound(calls_type_id.id()))?;
 
 				// Expect that type to be a variant:
 				let calls_type_def = calls_type.type_def();

--- a/core_v14/tests/decode_extrinsics.rs
+++ b/core_v14/tests/decode_extrinsics.rs
@@ -61,9 +61,10 @@ fn balance_transfer_signed() {
 	let d = decoder();
 
 	// Balances.transfer (amount: 12345)
-	let ext_bytes = to_bytes("0x31028400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d016ada9b477ef454972200e098f1186d4a2aeee776f1f6a68609797f5ba052906ad2427bdca865442158d118e2dfc82226077e4dfdff975d005685bab66eefa38a150200000500001cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07ce5c0");
-	let ext = d.decode_extrinsic(&ext_bytes).expect("can decode extrinsic");
+	let ext_bytes = &mut &*to_bytes("0x31028400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d016ada9b477ef454972200e098f1186d4a2aeee776f1f6a68609797f5ba052906ad2427bdca865442158d118e2dfc82226077e4dfdff975d005685bab66eefa38a150200000500001cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07ce5c0");
+	let ext = d.decode_extrinsic(ext_bytes).expect("can decode extrinsic");
 
+	assert!(ext_bytes.is_empty(), "No more bytes expected");
 	assert_eq!(ext.pallet, "Balances".to_string());
 	assert_eq!(ext.call, "transfer".to_string());
 	assert_eq!(ext.arguments.len(), 2);
@@ -75,9 +76,10 @@ fn balance_transfer_all_signed() {
 	let d = decoder();
 
 	// Balances.transfer_all (keepalive: false)
-	let ext_bytes = to_bytes("0x2d028400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d01f0431ffe387134b4f84d92d3c3f1ac18c0f42237ad7dbd455bb0cf8a18efb1760528f052b2219ad1601d9a4719e1a446cf307bf6d7e9c56175bfe6e7bf8cbe81450304000504001cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c00");
-	let ext = d.decode_extrinsic(&ext_bytes).expect("can decode extrinsic");
+	let ext_bytes = &mut &*to_bytes("0x2d028400d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d01f0431ffe387134b4f84d92d3c3f1ac18c0f42237ad7dbd455bb0cf8a18efb1760528f052b2219ad1601d9a4719e1a446cf307bf6d7e9c56175bfe6e7bf8cbe81450304000504001cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c00");
+	let ext = d.decode_extrinsic(ext_bytes).expect("can decode extrinsic");
 
+	assert!(ext_bytes.is_empty(), "No more bytes expected");
 	assert_eq!(ext.pallet, "Balances".to_string());
 	assert_eq!(ext.call, "transfer_all".to_string());
 	assert_eq!(ext.arguments.len(), 2);
@@ -92,9 +94,10 @@ fn auctions_bid_unsigned() {
 	let d = decoder();
 
 	// Auctions.bid (Args: (1,), 2, 3, 4, 5, all compact encoded).
-	let ext_bytes = to_bytes("0x04480104080c1014");
-	let ext = d.decode_unwrapped_extrinsic(&ext_bytes).expect("can decode extrinsic");
+	let ext_bytes = &mut &*to_bytes("0x04480104080c1014");
+	let ext = d.decode_unwrapped_extrinsic(ext_bytes).expect("can decode extrinsic");
 
+	assert!(ext_bytes.is_empty(), "No more bytes expected");
 	assert_eq!(ext.pallet, "Auctions".to_string());
 	assert_eq!(ext.call, "bid".to_string());
 	assert_eq!(ext.arguments.len(), 5);
@@ -116,9 +119,10 @@ fn system_fill_block_unsigned() {
 	let d = decoder();
 
 	// System.fill_block (Args: Perblock(1234)).
-	let ext_bytes = to_bytes("0x040000d2040000");
-	let ext = d.decode_unwrapped_extrinsic(&ext_bytes).expect("can decode extrinsic");
+	let ext_bytes = &mut &*to_bytes("0x040000d2040000");
+	let ext = d.decode_unwrapped_extrinsic(ext_bytes).expect("can decode extrinsic");
 
+	assert!(ext_bytes.is_empty(), "No more bytes expected");
 	assert_eq!(ext.pallet, "System".to_string());
 	assert_eq!(ext.call, "fill_block".to_string());
 	assert_eq!(ext.arguments.len(), 1);
@@ -136,9 +140,10 @@ fn technical_committee_execute_unsigned() {
 	let d = decoder();
 
 	// TechnicalCommittee.execute (Args: Balances.transfer(Alice -> Bob, 12345), 500).
-	let ext_bytes = to_bytes("0x0410010500001cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07ce5c0d107");
-	let ext = d.decode_unwrapped_extrinsic(&ext_bytes).expect("can decode extrinsic");
+	let ext_bytes = &mut &*to_bytes("0x0410010500001cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07ce5c0d107");
+	let ext = d.decode_unwrapped_extrinsic(ext_bytes).expect("can decode extrinsic");
 
+	assert!(ext_bytes.is_empty(), "No more bytes expected");
 	assert_eq!(ext.pallet, "TechnicalCommittee".to_string());
 	assert_eq!(ext.call, "execute".to_string());
 	assert_eq!(ext.arguments.len(), 2);
@@ -161,9 +166,10 @@ fn tips_report_awesome_unsigned() {
 	let d = decoder();
 
 	// Tips.report_awesome (Args: b"This person rocks!", AccountId).
-	let ext_bytes = to_bytes("0x042300485468697320706572736f6e20726f636b73211cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c");
-	let ext = d.decode_unwrapped_extrinsic(&ext_bytes).expect("can decode extrinsic");
+	let ext_bytes = &mut &*to_bytes("0x042300485468697320706572736f6e20726f636b73211cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07c");
+	let ext = d.decode_unwrapped_extrinsic(ext_bytes).expect("can decode extrinsic");
 
+	assert!(ext_bytes.is_empty(), "No more bytes expected");
 	assert_eq!(ext.pallet, "Tips".to_string());
 	assert_eq!(ext.call, "report_awesome".to_string());
 	assert_eq!(ext.arguments.len(), 2);
@@ -181,9 +187,10 @@ fn vesting_force_vested_transfer_unsigned() {
 	let d = decoder();
 
 	// Vesting.force_vested_transfer (Args: AccountId, AccountId, { locked: 1u128, perBlock: 2u128, startingBlock: 3u32 }).
-	let ext_bytes = to_bytes("0x04190300d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48010000000000000000000000000000000200000000000000000000000000000003000000");
-	let ext = d.decode_unwrapped_extrinsic(&ext_bytes).expect("can decode extrinsic");
+	let ext_bytes = &mut &*to_bytes("0x04190300d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d008eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48010000000000000000000000000000000200000000000000000000000000000003000000");
+	let ext = d.decode_unwrapped_extrinsic(ext_bytes).expect("can decode extrinsic");
 
+	assert!(ext_bytes.is_empty(), "No more bytes expected");
 	assert_eq!(ext.pallet, "Vesting".to_string());
 	assert_eq!(ext.call, "force_vested_transfer".to_string());
 	assert_eq!(ext.arguments.len(), 3);

--- a/core_v14/tests/decode_extrinsics.rs
+++ b/core_v14/tests/decode_extrinsics.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-desub.  If not, see <http://www.gnu.org/licenses/>.
 
-use core_v14::{value, Decoder, Metadata, Value, decoder::SignedExtensionWithAdditional};
+use core_v14::{decoder::SignedExtensionWithAdditional, value, Decoder, Metadata, Value};
 
 static V14_METADATA_POLKADOT_SCALE: &[u8] = include_bytes!("data/v14_metadata_polkadot.scale");
 
@@ -159,10 +159,7 @@ fn system_fill_block_unsigned() {
 	assert_eq!(&*ext.call_data.ty.name(), "fill_block");
 	assert_eq!(ext.call_data.arguments.len(), 1);
 
-	assert_eq!(
-		ext.call_data.arguments,
-		vec![singleton_value(prim_u32_value(1234))]
-	);
+	assert_eq!(ext.call_data.arguments, vec![singleton_value(prim_u32_value(1234))]);
 }
 
 /// This test is interesting because you provide a nested enum representing a call
@@ -172,7 +169,8 @@ fn technical_committee_execute_unsigned() {
 	let d = decoder();
 
 	// TechnicalCommittee.execute (Args: Balances.transfer(Alice -> Bob, 12345), 500).
-	let ext_bytes = &mut &*to_bytes("0x0410010500001cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07ce5c0d107");
+	let ext_bytes =
+		&mut &*to_bytes("0x0410010500001cbd2d43530a44705ad088af313e18f80b53ef16b36177cd4b77b846f2a5f07ce5c0d107");
 	let ext = d.decode_unwrapped_extrinsic(ext_bytes).expect("can decode extrinsic");
 
 	assert!(ext_bytes.is_empty(), "No more bytes expected");
@@ -208,9 +206,7 @@ fn tips_report_awesome_unsigned() {
 
 	assert_eq!(
 		&ext.call_data.arguments[0],
-		&Value::Composite(value::Composite::Unnamed(
-			"This person rocks!".bytes().map(prim_u8_value).collect()
-		))
+		&Value::Composite(value::Composite::Unnamed("This person rocks!".bytes().map(prim_u8_value).collect()))
 	);
 }
 
@@ -257,31 +253,53 @@ fn test_signer_payload() {
 				"CheckSpecVersion".into(),
 				SignedExtensionWithAdditional { extension: empty_value(), additional: prim_u32_value(9110) }
 			),
-			("CheckTxVersion".into(), SignedExtensionWithAdditional { extension: empty_value(), additional: prim_u32_value(8) }),
+			(
+				"CheckTxVersion".into(),
+				SignedExtensionWithAdditional { extension: empty_value(), additional: prim_u32_value(8) }
+			),
 			(
 				"CheckGenesis".into(),
 				SignedExtensionWithAdditional {
 					extension: empty_value(),
-					additional: hash_value(to_bytes("0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3"))
+					additional: hash_value(to_bytes(
+						"0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3"
+					))
 				}
 			),
 			(
 				"CheckMortality".into(),
 				SignedExtensionWithAdditional {
-					extension: singleton_value(variant_value("Mortal185", value::Composite::Unnamed(vec![prim_u8_value(52)]))),
-					additional: hash_value(to_bytes("0x1c81d421f68281950ad2901291603b5e49fc5c872f129e75433f4b55f07ca072"))
+					extension: singleton_value(variant_value(
+						"Mortal185",
+						value::Composite::Unnamed(vec![prim_u8_value(52)])
+					)),
+					additional: hash_value(to_bytes(
+						"0x1c81d421f68281950ad2901291603b5e49fc5c872f129e75433f4b55f07ca072"
+					))
 				}
 			),
 			(
 				"CheckNonce".into(),
-				SignedExtensionWithAdditional { extension: singleton_value(prim_u32_value(0)), additional: empty_value() }
+				SignedExtensionWithAdditional {
+					extension: singleton_value(prim_u32_value(0)),
+					additional: empty_value()
+				}
 			),
-			("CheckWeight".into(), SignedExtensionWithAdditional { extension: empty_value(), additional: empty_value() }),
+			(
+				"CheckWeight".into(),
+				SignedExtensionWithAdditional { extension: empty_value(), additional: empty_value() }
+			),
 			(
 				"ChargeTransactionPayment".into(),
-				SignedExtensionWithAdditional { extension: singleton_value(prim_u128_value(0)), additional: empty_value() }
+				SignedExtensionWithAdditional {
+					extension: singleton_value(prim_u128_value(0)),
+					additional: empty_value()
+				}
 			),
-			("PrevalidateAttests".into(), SignedExtensionWithAdditional { extension: empty_value(), additional: empty_value() }),
+			(
+				"PrevalidateAttests".into(),
+				SignedExtensionWithAdditional { extension: empty_value(), additional: empty_value() }
+			),
 		],
 	);
 }


### PR DESCRIPTION
This PR builds on @noch3's work to add decoding for the signer payload. It also exposes the Variant type in the call data, so that you can access the name and details about each field, and it exposes scale_info more directly, and a means of getting hold of the type registry from our metadata.

Noch3's PR exposed the cursor approach (using input like `&mut &[u8]`); I felt like this made it easier to decide how to handle remaining bytes, and decode bits from a stream, so I consistified the rest of the decode API on this approach too.

I'm also experimenting here with returning references wherever possible when decoding to save some allocations when they may not be needed.

A couple of thoughts/questions:
- Is it worth having the Owned variants of these structs around or should it be left to users to clone/own whatever they want from them?
- I'm exposing the Variant type in the call data info. I'm not super confortable about mingling types and values in the output (at least, w.r.t converting to owned structs). Curious how others feel on this!