### PR TITLE
Parameterise Value type to add context (eg TypeId)

### DIFF
--- a/desub-current/src/decoder/decode_storage.rs
+++ b/desub-current/src/decoder/decode_storage.rs
@@ -193,7 +193,7 @@ impl StorageDecoder {
 //
 // See https://github.com/paritytech/subxt/blob/793c945fbd2de022f523c39a84ee02609ba423a9/codegen/src/api/storage.rs#L105
 // for another example of this being handled in code.
-fn storage_map_key_to_type_id_vec<'a>(metadata: &'a Metadata, key: &ScaleInfoTypeId) -> Vec<TypeId> {
+fn storage_map_key_to_type_id_vec(metadata: &Metadata, key: &ScaleInfoTypeId) -> Vec<TypeId> {
 	let ty = match metadata.resolve(key) {
 		Some(ty) => ty,
 		None => panic!("Metadata inconsistency: type #{} not found", key.id()),

--- a/desub-current/src/decoder/decode_storage.rs
+++ b/desub-current/src/decoder/decode_storage.rs
@@ -1,6 +1,6 @@
 use super::Value;
 use crate::metadata::{Metadata, StorageLocation};
-use crate::{TypeId, ScaleInfoTypeId};
+use crate::{ScaleInfoTypeId, TypeId};
 use frame_metadata::v14::StorageEntryType as FrameStorageEntryType;
 use serde::Serialize;
 use sp_core::twox_128;
@@ -149,11 +149,7 @@ impl StorageDecoder {
 					// Move the byte cursor forwards and push an entry to our storage keys:
 					let hash_bytes = &bytes[..bytes_consumed];
 					*bytes = &bytes[bytes_consumed..];
-					storage_keys.push(StorageMapKey {
-						bytes: Cow::Borrowed(hash_bytes),
-						hasher,
-						ty,
-					});
+					storage_keys.push(StorageMapKey { bytes: Cow::Borrowed(hash_bytes), hasher, ty });
 				}
 
 				Ok(StorageEntry {
@@ -201,11 +197,7 @@ fn storage_map_key_to_type_id_vec(metadata: &Metadata, key: &ScaleInfoTypeId) ->
 
 	match ty.type_def() {
 		// Multiple keys:
-		scale_info::TypeDef::Tuple(vals) => vals
-			.fields()
-			.iter()
-			.map(|f| TypeId::from_u32(f.id()))
-			.collect(),
+		scale_info::TypeDef::Tuple(vals) => vals.fields().iter().map(|f| TypeId::from_u32(f.id())).collect(),
 		// Single key:
 		_ => vec![key.into()],
 	}
@@ -277,11 +269,7 @@ pub struct StorageMapKey<'b> {
 
 impl<'m, 'b> StorageMapKey<'b> {
 	pub fn into_owned(self) -> StorageMapKey<'static> {
-		StorageMapKey {
-			bytes: Cow::Owned(self.bytes.into_owned()),
-			ty: self.ty,
-			hasher: self.hasher,
-		}
+		StorageMapKey { bytes: Cow::Owned(self.bytes.into_owned()), ty: self.ty, hasher: self.hasher }
 	}
 }
 

--- a/desub-current/src/decoder/decode_value.rs
+++ b/desub-current/src/decoder/decode_value.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-desub.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::value::{BitSequence, Composite, Primitive, Value, Variant};
+use crate::value::{BitSequence, Composite, Primitive, Value, ValueDef, Variant};
 use crate::{Type, TypeId};
 use codec::{Compact, Decode};
 use scale_info::{
@@ -41,39 +41,36 @@ pub enum DecodeValueError {
 	CannotDecodeCompactIntoType(Type),
 }
 
-/// Decode data according to the [`Type`] provided.
-/// The provided pointer to the data slice will be moved forwards as needed
-/// depending on what was decoded.
-pub fn decode_value(data: &mut &[u8], ty: &Type, types: &PortableRegistry) -> Result<Value, DecodeValueError> {
-	match ty.type_def() {
-		TypeDef::Composite(inner) => decode_composite_value(data, inner, types).map(Value::Composite),
-		TypeDef::Sequence(inner) => decode_sequence_value(data, inner, types).map(Value::Composite),
-		TypeDef::Array(inner) => decode_array_value(data, inner, types).map(Value::Composite),
-		TypeDef::Tuple(inner) => decode_tuple_value(data, inner, types).map(Value::Composite),
-		TypeDef::Variant(inner) => decode_variant_value(data, inner, types).map(Value::Variant),
-		TypeDef::Primitive(inner) => decode_primitive_value(data, inner).map(Value::Primitive),
-		TypeDef::Compact(inner) => decode_compact_value(data, inner, types),
-		TypeDef::BitSequence(inner) => decode_bit_sequence_value(data, inner, types).map(Value::BitSequence),
-	}
-}
-
 /// Decode data according to the [`TypeId`] provided.
 /// The provided pointer to the data slice will be moved forwards as needed
 /// depending on what was decoded.
-pub fn decode_value_by_id(
+pub fn decode_value_by_id<Id: Into<TypeId>>(
 	data: &mut &[u8],
-	ty_id: &TypeId,
+	ty_id: Id,
 	types: &PortableRegistry,
-) -> Result<Value, DecodeValueError> {
-	let inner_ty = types.resolve(ty_id.id()).ok_or_else(|| DecodeValueError::TypeIdNotFound(ty_id.id()))?;
-	decode_value(data, inner_ty, types)
+) -> Result<Value<TypeId>, DecodeValueError> {
+	let ty_id = ty_id.into();
+	let ty = types.resolve(ty_id.id()).ok_or_else(|| DecodeValueError::TypeIdNotFound(ty_id.id()))?;
+
+	let value = match ty.type_def() {
+		TypeDef::Composite(inner) => decode_composite_value(data, inner, types).map(ValueDef::Composite),
+		TypeDef::Sequence(inner) => decode_sequence_value(data, inner, types).map(ValueDef::Composite),
+		TypeDef::Array(inner) => decode_array_value(data, inner, types).map(ValueDef::Composite),
+		TypeDef::Tuple(inner) => decode_tuple_value(data, inner, types).map(ValueDef::Composite),
+		TypeDef::Variant(inner) => decode_variant_value(data, inner, types).map(ValueDef::Variant),
+		TypeDef::Primitive(inner) => decode_primitive_value(data, inner).map(ValueDef::Primitive),
+		TypeDef::Compact(inner) => decode_compact_value(data, inner, types),
+		TypeDef::BitSequence(inner) => decode_bit_sequence_value(data, inner, types).map(ValueDef::BitSequence),
+	}?;
+
+	Ok(Value { value, context: ty_id })
 }
 
 fn decode_composite_value(
 	data: &mut &[u8],
 	ty: &TypeDefComposite<PortableForm>,
 	types: &PortableRegistry,
-) -> Result<Composite, DecodeValueError> {
+) -> Result<Composite<TypeId>, DecodeValueError> {
 	decode_fields(data, ty.fields(), types)
 }
 
@@ -81,7 +78,7 @@ fn decode_variant_value(
 	data: &mut &[u8],
 	ty: &TypeDefVariant<PortableForm>,
 	types: &PortableRegistry,
-) -> Result<Variant, DecodeValueError> {
+) -> Result<Variant<TypeId>, DecodeValueError> {
 	let index = *data.get(0).ok_or(DecodeValueError::Eof)?;
 	*data = &data[1..];
 
@@ -101,7 +98,7 @@ fn decode_fields(
 	data: &mut &[u8],
 	fields: &[Field<PortableForm>],
 	types: &PortableRegistry,
-) -> Result<Composite, DecodeValueError> {
+) -> Result<Composite<TypeId>, DecodeValueError> {
 	let are_named = fields.iter().any(|f| f.name().is_some());
 	let named_field_vals = fields.iter().map(|f| {
 		let name = f.name().cloned().unwrap_or_default();
@@ -121,7 +118,7 @@ fn decode_sequence_value(
 	data: &mut &[u8],
 	ty: &TypeDefSequence<PortableForm>,
 	types: &PortableRegistry,
-) -> Result<Composite, DecodeValueError> {
+) -> Result<Composite<TypeId>, DecodeValueError> {
 	// We assume that the sequence is preceeded by a compact encoded length, so that
 	// we know how many values to try pulling out of the data.
 	let len = Compact::<u64>::decode(data)?;
@@ -135,7 +132,7 @@ fn decode_array_value(
 	data: &mut &[u8],
 	ty: &TypeDefArray<PortableForm>,
 	types: &PortableRegistry,
-) -> Result<Composite, DecodeValueError> {
+) -> Result<Composite<TypeId>, DecodeValueError> {
 	// The length is known based on the type we want to decode into, so we pull out the number of items according
 	// to that, and don't need a length to exist in the SCALE encoded bytes
 	let values: Vec<_> =
@@ -148,7 +145,7 @@ fn decode_tuple_value(
 	data: &mut &[u8],
 	ty: &TypeDefTuple<PortableForm>,
 	types: &PortableRegistry,
-) -> Result<Composite, DecodeValueError> {
+) -> Result<Composite<TypeId>, DecodeValueError> {
 	let values: Vec<_> = ty.fields().iter().map(|f| decode_value_by_id(data, f, types)).collect::<Result<_, _>>()?;
 
 	Ok(Composite::Unnamed(values))
@@ -183,16 +180,16 @@ fn decode_compact_value(
 	data: &mut &[u8],
 	ty: &TypeDefCompact<PortableForm>,
 	types: &PortableRegistry,
-) -> Result<Value, DecodeValueError> {
-	fn decode_compact(data: &mut &[u8], inner: &Type, types: &PortableRegistry) -> Result<Value, DecodeValueError> {
+) -> Result<ValueDef<TypeId>, DecodeValueError> {
+	fn decode_compact(data: &mut &[u8], inner: &Type, types: &PortableRegistry) -> Result<ValueDef<TypeId>, DecodeValueError> {
 		use TypeDefPrimitive::*;
 		let val = match inner.type_def() {
 			// It's obvious how to decode basic primitive unsigned types, since we have impls for them.
-			TypeDef::Primitive(U8) => Value::Primitive(Primitive::U8(Compact::<u8>::decode(data)?.0)),
-			TypeDef::Primitive(U16) => Value::Primitive(Primitive::U16(Compact::<u16>::decode(data)?.0)),
-			TypeDef::Primitive(U32) => Value::Primitive(Primitive::U32(Compact::<u32>::decode(data)?.0)),
-			TypeDef::Primitive(U64) => Value::Primitive(Primitive::U64(Compact::<u64>::decode(data)?.0)),
-			TypeDef::Primitive(U128) => Value::Primitive(Primitive::U128(Compact::<u128>::decode(data)?.0)),
+			TypeDef::Primitive(U8) => ValueDef::Primitive(Primitive::U8(Compact::<u8>::decode(data)?.0)),
+			TypeDef::Primitive(U16) => ValueDef::Primitive(Primitive::U16(Compact::<u16>::decode(data)?.0)),
+			TypeDef::Primitive(U32) => ValueDef::Primitive(Primitive::U32(Compact::<u32>::decode(data)?.0)),
+			TypeDef::Primitive(U64) => ValueDef::Primitive(Primitive::U64(Compact::<u64>::decode(data)?.0)),
+			TypeDef::Primitive(U128) => ValueDef::Primitive(Primitive::U128(Compact::<u128>::decode(data)?.0)),
 			// A struct with exactly 1 field containing one of the above types can be sensibly compact encoded/decoded.
 			TypeDef::Composite(composite) => {
 				if composite.fields().len() != 1 {
@@ -206,7 +203,10 @@ fn decode_compact_value(
 
 				// Decode this inner type via compact decoding. This can recurse, in case
 				// the inner type is also a 1-field composite type.
-				let inner_value = decode_compact(data, inner_ty, types)?;
+				let inner_value = Value {
+					value: decode_compact(data, inner_ty, types)?,
+					context: field.ty().into()
+				};
 
 				// Wrap the inner type in a representation of this outer composite type.
 				let composite = match field.name() {
@@ -214,7 +214,7 @@ fn decode_compact_value(
 					None => Composite::Unnamed(vec![inner_value]),
 				};
 
-				Value::Composite(composite)
+				ValueDef::Composite(composite)
 			}
 			// For now, we give up if we have been asked for any other type:
 			_cannot_decode_from => return Err(DecodeValueError::CannotDecodeCompactIntoType(inner.clone())),
@@ -249,32 +249,37 @@ mod test {
 
 	/// Given a type definition, return the PortableType and PortableRegistry
 	/// that our decode functions expect.
-	fn make_type(ty: scale_info::Type) -> (Type, PortableRegistry) {
+	fn make_type(ty: scale_info::Type) -> (TypeId, PortableRegistry) {
 		use scale_info::IntoPortable;
+		// Make registry:
 		let mut types = scale_info::Registry::new();
-		let portable_ty: Type = ty.into_portable(&mut types);
-		(portable_ty, types.into())
+		// Insert a single type into it:
+		let t = ty.into_portable(&mut types);
+		// make registry portable:
+		let portable_registry: PortableRegistry = types.into();
+		// We know type Id will be 0, since only 1 type in registry:
+		(TypeId::from_u32(1), portable_registry)
 	}
 
 	/// Given a value to encode, and a representation of the decoded value, check that our decode functions
 	/// successfully decodes the type to the expected value, based on the implicit SCALE type info that the type
 	/// carries
-	fn encode_decode_check<T: Encode + scale_info::TypeInfo>(val: T, exp: Value) {
+	fn encode_decode_check<T: Encode + scale_info::TypeInfo>(val: T, exp: ValueDef<()>) {
 		encode_decode_check_explicit_info(val, T::type_info(), exp)
 	}
 
 	/// Given a value to encode, a type to decode it back into, and a representation of
 	/// the decoded value, check that our decode functions successfully decodes as expected.
-	fn encode_decode_check_explicit_info<T: Encode, Ty: Into<scale_info::Type>>(val: T, ty: Ty, ex: Value) {
+	fn encode_decode_check_explicit_info<T: Encode, Ty: Into<scale_info::Type>>(val: T, ty: Ty, ex: ValueDef<()>) {
 		let encoded = val.encode();
 		let encoded = &mut &*encoded;
 
-		let (portable_ty, portable_registry) = make_type(ty.into());
+		let (id, portable_registry) = make_type(ty.into());
 
 		// Can we decode?
-		let val = decode_value(encoded, &portable_ty, &portable_registry).expect("decoding failed");
+		let val = decode_value_by_id(encoded, id, &portable_registry).expect("decoding failed");
 		// Is the decoded value what we expected?
-		assert_eq!(val, ex, "decoded value does not look like what we expected");
+		assert_eq!(val.value.without_context(), ex, "decoded value does not look like what we expected");
 		// Did decoding consume all of the encoded bytes, as expected?
 		assert_eq!(encoded.len(), 0, "decoding did not consume all of the encoded bytes");
 	}
@@ -283,41 +288,41 @@ mod test {
 	fn decode_primitives() {
 		use scale_info::TypeDefPrimitive;
 
-		encode_decode_check(true, Value::Primitive(Primitive::Bool(true)));
-		encode_decode_check(false, Value::Primitive(Primitive::Bool(false)));
-		encode_decode_check_explicit_info('a' as u32, TypeDefPrimitive::Char, Value::Primitive(Primitive::Char('a')));
-		encode_decode_check("hello", Value::Primitive(Primitive::Str("hello".into())));
+		encode_decode_check(true, ValueDef::Primitive(Primitive::Bool(true)));
+		encode_decode_check(false, ValueDef::Primitive(Primitive::Bool(false)));
+		encode_decode_check_explicit_info('a' as u32, TypeDefPrimitive::Char, ValueDef::Primitive(Primitive::Char('a')));
+		encode_decode_check("hello", ValueDef::Primitive(Primitive::Str("hello".into())));
 		encode_decode_check(
 			"hello".to_string(), // String or &str (above) decode OK
-			Value::Primitive(Primitive::Str("hello".into())),
+			ValueDef::Primitive(Primitive::Str("hello".into())),
 		);
-		encode_decode_check(123u8, Value::Primitive(Primitive::U8(123)));
-		encode_decode_check(123u16, Value::Primitive(Primitive::U16(123)));
-		encode_decode_check(123u32, Value::Primitive(Primitive::U32(123)));
-		encode_decode_check(123u64, Value::Primitive(Primitive::U64(123)));
+		encode_decode_check(123u8, ValueDef::Primitive(Primitive::U8(123)));
+		encode_decode_check(123u16, ValueDef::Primitive(Primitive::U16(123)));
+		encode_decode_check(123u32, ValueDef::Primitive(Primitive::U32(123)));
+		encode_decode_check(123u64, ValueDef::Primitive(Primitive::U64(123)));
 		encode_decode_check_explicit_info(
 			[123u8; 32], // Anything 32 bytes long will do here
 			TypeDefPrimitive::U256,
-			Value::Primitive(Primitive::U256([123u8; 32])),
+			ValueDef::Primitive(Primitive::U256([123u8; 32])),
 		);
-		encode_decode_check(123i8, Value::Primitive(Primitive::I8(123)));
-		encode_decode_check(123i16, Value::Primitive(Primitive::I16(123)));
-		encode_decode_check(123i32, Value::Primitive(Primitive::I32(123)));
-		encode_decode_check(123i64, Value::Primitive(Primitive::I64(123)));
+		encode_decode_check(123i8, ValueDef::Primitive(Primitive::I8(123)));
+		encode_decode_check(123i16, ValueDef::Primitive(Primitive::I16(123)));
+		encode_decode_check(123i32, ValueDef::Primitive(Primitive::I32(123)));
+		encode_decode_check(123i64, ValueDef::Primitive(Primitive::I64(123)));
 		encode_decode_check_explicit_info(
 			[123u8; 32], // Anything 32 bytes long will do here
 			TypeDefPrimitive::I256,
-			Value::Primitive(Primitive::I256([123u8; 32])),
+			ValueDef::Primitive(Primitive::I256([123u8; 32])),
 		);
 	}
 
 	#[test]
 	fn decode_compact_primitives() {
-		encode_decode_check(Compact(123u8), Value::Primitive(Primitive::U8(123)));
-		encode_decode_check(Compact(123u16), Value::Primitive(Primitive::U16(123)));
-		encode_decode_check(Compact(123u32), Value::Primitive(Primitive::U32(123)));
-		encode_decode_check(Compact(123u64), Value::Primitive(Primitive::U64(123)));
-		encode_decode_check(Compact(123u128), Value::Primitive(Primitive::U128(123)));
+		encode_decode_check(Compact(123u8), ValueDef::Primitive(Primitive::U8(123)));
+		encode_decode_check(Compact(123u16), ValueDef::Primitive(Primitive::U16(123)));
+		encode_decode_check(Compact(123u32), ValueDef::Primitive(Primitive::U32(123)));
+		encode_decode_check(Compact(123u64), ValueDef::Primitive(Primitive::U64(123)));
+		encode_decode_check(Compact(123u128), ValueDef::Primitive(Primitive::U128(123)));
 	}
 
 	#[test]
@@ -345,7 +350,7 @@ mod test {
 
 		encode_decode_check(
 			Compact(MyWrapper { inner: 123 }),
-			Value::Composite(Composite::Named(vec![("inner".to_string(), Value::Primitive(Primitive::U32(123)))])),
+			ValueDef::Composite(Composite::Named(vec![("inner".to_string(), Value::new(ValueDef::Primitive(Primitive::U32(123))))])),
 		);
 	}
 
@@ -377,7 +382,7 @@ mod test {
 
 		encode_decode_check(
 			Compact(MyWrapper(123)),
-			Value::Composite(Composite::Unnamed(vec![Value::Primitive(Primitive::U32(123))])),
+			ValueDef::Composite(Composite::Unnamed(vec![Value::new(ValueDef::Primitive(Primitive::U32(123)))])),
 		);
 	}
 
@@ -385,26 +390,26 @@ mod test {
 	fn decode_sequence_array_tuple_types() {
 		encode_decode_check(
 			vec![1i32, 2, 3],
-			Value::Composite(Composite::Unnamed(vec![
-				Value::Primitive(Primitive::I32(1)),
-				Value::Primitive(Primitive::I32(2)),
-				Value::Primitive(Primitive::I32(3)),
+			ValueDef::Composite(Composite::Unnamed(vec![
+				Value::new(ValueDef::Primitive(Primitive::I32(1))),
+				Value::new(ValueDef::Primitive(Primitive::I32(2))),
+				Value::new(ValueDef::Primitive(Primitive::I32(3))),
 			])),
 		);
 		encode_decode_check(
 			[1i32, 2, 3], //compile-time length known
-			Value::Composite(Composite::Unnamed(vec![
-				Value::Primitive(Primitive::I32(1)),
-				Value::Primitive(Primitive::I32(2)),
-				Value::Primitive(Primitive::I32(3)),
+			ValueDef::Composite(Composite::Unnamed(vec![
+				Value::new(ValueDef::Primitive(Primitive::I32(1))),
+				Value::new(ValueDef::Primitive(Primitive::I32(2))),
+				Value::new(ValueDef::Primitive(Primitive::I32(3))),
 			])),
 		);
 		encode_decode_check(
 			(1i32, true, 123456u128),
-			Value::Composite(Composite::Unnamed(vec![
-				Value::Primitive(Primitive::I32(1)),
-				Value::Primitive(Primitive::Bool(true)),
-				Value::Primitive(Primitive::U128(123456)),
+			ValueDef::Composite(Composite::Unnamed(vec![
+				Value::new(ValueDef::Primitive(Primitive::I32(1))),
+				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+				Value::new(ValueDef::Primitive(Primitive::U128(123456))),
 			])),
 		);
 	}
@@ -419,18 +424,18 @@ mod test {
 
 		encode_decode_check(
 			MyEnum::Foo(true),
-			Value::Variant(Variant {
+			ValueDef::Variant(Variant {
 				name: "Foo".to_string(),
-				values: Composite::Unnamed(vec![Value::Primitive(Primitive::Bool(true))]),
+				values: Composite::Unnamed(vec![Value::new(ValueDef::Primitive(Primitive::Bool(true)))]),
 			}),
 		);
 		encode_decode_check(
 			MyEnum::Bar { hi: "hello".to_string(), other: 123 },
-			Value::Variant(Variant {
+			ValueDef::Variant(Variant {
 				name: "Bar".to_string(),
 				values: Composite::Named(vec![
-					("hi".to_string(), Value::Primitive(Primitive::Str("hello".to_string()))),
-					("other".to_string(), Value::Primitive(Primitive::U128(123))),
+					("hi".to_string(), Value::new(ValueDef::Primitive(Primitive::Str("hello".to_string())))),
+					("other".to_string(), Value::new(ValueDef::Primitive(Primitive::U128(123)))),
 				]),
 			}),
 		);
@@ -450,28 +455,28 @@ mod test {
 
 		encode_decode_check(
 			Unnamed(true, "James".into(), vec![1, 2, 3]),
-			Value::Composite(Composite::Unnamed(vec![
-				Value::Primitive(Primitive::Bool(true)),
-				Value::Primitive(Primitive::Str("James".to_string())),
-				Value::Composite(Composite::Unnamed(vec![
-					Value::Primitive(Primitive::U8(1)),
-					Value::Primitive(Primitive::U8(2)),
-					Value::Primitive(Primitive::U8(3)),
-				])),
+			ValueDef::Composite(Composite::Unnamed(vec![
+				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+				Value::new(ValueDef::Primitive(Primitive::Str("James".to_string()))),
+				Value::new(ValueDef::Composite(Composite::Unnamed(vec![
+					Value::new(ValueDef::Primitive(Primitive::U8(1))),
+					Value::new(ValueDef::Primitive(Primitive::U8(2))),
+					Value::new(ValueDef::Primitive(Primitive::U8(3))),
+				]))),
 			])),
 		);
 		encode_decode_check(
 			Named { is_valid: true, name: "James".into(), bytes: vec![1, 2, 3] },
-			Value::Composite(Composite::Named(vec![
-				("is_valid".into(), Value::Primitive(Primitive::Bool(true))),
-				("name".into(), Value::Primitive(Primitive::Str("James".to_string()))),
+			ValueDef::Composite(Composite::Named(vec![
+				("is_valid".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
+				("name".into(), Value::new(ValueDef::Primitive(Primitive::Str("James".to_string())))),
 				(
 					"bytes".into(),
-					Value::Composite(Composite::Unnamed(vec![
-						Value::Primitive(Primitive::U8(1)),
-						Value::Primitive(Primitive::U8(2)),
-						Value::Primitive(Primitive::U8(3)),
-					])),
+					Value::new(ValueDef::Composite(Composite::Unnamed(vec![
+						Value::new(ValueDef::Primitive(Primitive::U8(1))),
+						Value::new(ValueDef::Primitive(Primitive::U8(2))),
+						Value::new(ValueDef::Primitive(Primitive::U8(3))),
+					]))),
 				),
 			])),
 		);
@@ -483,7 +488,7 @@ mod test {
 
 		encode_decode_check(
 			bitvec![Lsb0, u8; 0, 1, 1, 0, 1, 0],
-			Value::BitSequence(bitvec![Lsb0, u8; 0, 1, 1, 0, 1, 0]),
+			ValueDef::BitSequence(bitvec![Lsb0, u8; 0, 1, 1, 0, 1, 0]),
 		);
 	}
 }

--- a/desub-current/src/decoder/decode_value.rs
+++ b/desub-current/src/decoder/decode_value.rs
@@ -181,7 +181,11 @@ fn decode_compact_value(
 	ty: &TypeDefCompact<PortableForm>,
 	types: &PortableRegistry,
 ) -> Result<ValueDef<TypeId>, DecodeValueError> {
-	fn decode_compact(data: &mut &[u8], inner: &Type, types: &PortableRegistry) -> Result<ValueDef<TypeId>, DecodeValueError> {
+	fn decode_compact(
+		data: &mut &[u8],
+		inner: &Type,
+		types: &PortableRegistry,
+	) -> Result<ValueDef<TypeId>, DecodeValueError> {
 		use TypeDefPrimitive::*;
 		let val = match inner.type_def() {
 			// It's obvious how to decode basic primitive unsigned types, since we have impls for them.
@@ -203,10 +207,7 @@ fn decode_compact_value(
 
 				// Decode this inner type via compact decoding. This can recurse, in case
 				// the inner type is also a 1-field composite type.
-				let inner_value = Value {
-					value: decode_compact(data, inner_ty, types)?,
-					context: field.ty().into()
-				};
+				let inner_value = Value { value: decode_compact(data, inner_ty, types)?, context: field.ty().into() };
 
 				// Wrap the inner type in a representation of this outer composite type.
 				let composite = match field.name() {
@@ -262,7 +263,7 @@ mod test {
 	/// successfully decodes the type to the expected value, based on the implicit SCALE type info that the type
 	/// carries
 	fn encode_decode_check<T: Encode + scale_info::TypeInfo + 'static>(val: T, exp: Value<()>) {
-		encode_decode_check_explicit_info::<T,_>(val, exp)
+		encode_decode_check_explicit_info::<T, _>(val, exp)
 	}
 
 	/// Given a value to encode, a type to decode it back into, and a representation of
@@ -285,7 +286,7 @@ mod test {
 	fn decode_primitives() {
 		encode_decode_check(true, Value::bool(true));
 		encode_decode_check(false, Value::bool(false));
-		encode_decode_check_explicit_info::<char,_>('a' as u32, Value::char('a'));
+		encode_decode_check_explicit_info::<char, _>('a' as u32, Value::char('a'));
 		encode_decode_check("hello", Value::str("hello".into()));
 		encode_decode_check(
 			"hello".to_string(), // String or &str (above) decode OK
@@ -375,37 +376,22 @@ mod test {
 			}
 		}
 
-		encode_decode_check(
-			Compact(MyWrapper(123)),
-			Value::unnamed_composite(vec![Value::u32(123)]),
-		);
+		encode_decode_check(Compact(MyWrapper(123)), Value::unnamed_composite(vec![Value::u32(123)]));
 	}
 
 	#[test]
 	fn decode_sequence_array_tuple_types() {
 		encode_decode_check(
 			vec![1i32, 2, 3],
-			Value::unnamed_composite(vec![
-				Value::i32(1),
-				Value::i32(2),
-				Value::i32(3),
-			]),
+			Value::unnamed_composite(vec![Value::i32(1), Value::i32(2), Value::i32(3)]),
 		);
 		encode_decode_check(
 			[1i32, 2, 3], //compile-time length known
-			Value::unnamed_composite(vec![
-				Value::i32(1),
-				Value::i32(2),
-				Value::i32(3),
-			]),
+			Value::unnamed_composite(vec![Value::i32(1), Value::i32(2), Value::i32(3)]),
 		);
 		encode_decode_check(
 			(1i32, true, 123456u128),
-			Value::unnamed_composite(vec![
-				Value::i32(1),
-				Value::bool(true),
-				Value::u128(123456),
-			]),
+			Value::unnamed_composite(vec![Value::i32(1), Value::bool(true), Value::u128(123456)]),
 		);
 	}
 
@@ -419,18 +405,17 @@ mod test {
 
 		encode_decode_check(
 			MyEnum::Foo(true),
-			Value::variant("Foo".to_string(),
-				Composite::Unnamed(vec![Value::bool(true)])
-			)
+			Value::variant("Foo".to_string(), Composite::Unnamed(vec![Value::bool(true)])),
 		);
 		encode_decode_check(
 			MyEnum::Bar { hi: "hello".to_string(), other: 123 },
-			Value::variant("Bar".to_string(),
-			Composite::Named(vec![
+			Value::variant(
+				"Bar".to_string(),
+				Composite::Named(vec![
 					("hi".to_string(), Value::str("hello".to_string())),
 					("other".to_string(), Value::u128(123)),
-				])
-			)
+				]),
+			),
 		);
 	}
 
@@ -451,11 +436,7 @@ mod test {
 			Value::unnamed_composite(vec![
 				Value::bool(true),
 				Value::str("James".to_string()),
-				Value::unnamed_composite(vec![
-					Value::u8(1),
-					Value::u8(2),
-					Value::u8(3),
-				]),
+				Value::unnamed_composite(vec![Value::u8(1), Value::u8(2), Value::u8(3)]),
 			]),
 		);
 		encode_decode_check(
@@ -463,15 +444,8 @@ mod test {
 			Value::named_composite(vec![
 				("is_valid".into(), Value::bool(true)),
 				("name".into(), Value::str("James".to_string())),
-				(
-					"bytes".into(),
-					Value::unnamed_composite(vec![
-						Value::u8(1),
-						Value::u8(2),
-						Value::u8(3),
-					]),
-				),
-			])
+				("bytes".into(), Value::unnamed_composite(vec![Value::u8(1), Value::u8(2), Value::u8(3)])),
+			]),
 		);
 	}
 

--- a/desub-current/src/decoder/mod.rs
+++ b/desub-current/src/decoder/mod.rs
@@ -85,7 +85,7 @@ pub fn decode_value_by_id<'a, Id: Into<TypeId>>(
 /// use desub_current::{
 ///     Metadata,
 ///     decoder::{ self, StorageHasher },
-///     value::{ Value, Composite, Primitive },
+///     value::{ Value, ValueDef, Composite, Primitive },
 /// };
 /// use codec::Encode;
 ///
@@ -113,20 +113,24 @@ pub fn decode_value_by_id<'a, Id: Into<TypeId>>(
 ///
 /// // Because the hasher is Twox64Concat, we can see the decoded original map key:
 /// assert_eq!(keys.len(), 1);
-/// assert_eq!(keys[0].hasher, StorageHasher::Twox64Concat(Value::Primitive(Primitive::U32(1000))));
+/// if let StorageHasher::Twox64Concat(val) = keys[0].hasher.clone() {
+///     assert_eq!(val.without_context(), Value::new(ValueDef::Primitive(Primitive::U32(1000))))
+/// }
 ///
 /// // We can also decode values at this storage location using the type info we get back:
 /// let bytes = [1u8; 32].encode();
 /// let val = decoder::decode_value_by_id(&metadata, &entry.ty, &mut &*bytes).unwrap();
 /// # assert_eq!(
-/// #     val,
+/// #     val.without_context(),
 /// #     // The Type in this case is something like a newtype-wrapped [u8; 32]:
-/// #     Value::Composite(Composite::Unnamed(vec![Value::Composite(Composite::Unnamed(vec![
-/// #         Value::Primitive(
-/// #             Primitive::U8(1)
-/// #         );
-/// #         32
-/// #     ]))]))
+/// #     Value::new(ValueDef::Composite(Composite::Unnamed(vec![
+/// #         Value::new(ValueDef::Composite(Composite::Unnamed(vec![
+/// #             Value::new(ValueDef::Primitive(
+/// #                 Primitive::U8(1)
+/// #             ));
+/// #             32
+/// #         ])))
+/// #    ])))
 /// # );
 /// ```
 pub fn decode_storage(metadata: &Metadata) -> StorageDecoder {

--- a/desub-current/src/decoder/mod.rs
+++ b/desub-current/src/decoder/mod.rs
@@ -114,7 +114,7 @@ pub fn decode_value_by_id<'a, Id: Into<TypeId>>(
 /// // Because the hasher is Twox64Concat, we can see the decoded original map key:
 /// assert_eq!(keys.len(), 1);
 /// if let StorageHasher::Twox64Concat(val) = keys[0].hasher.clone() {
-///     assert_eq!(val.without_context(), Value::new(ValueDef::Primitive(Primitive::U32(1000))))
+///     assert_eq!(val.without_context(), Value::u32(1000))
 /// }
 ///
 /// // We can also decode values at this storage location using the type info we get back:
@@ -123,14 +123,9 @@ pub fn decode_value_by_id<'a, Id: Into<TypeId>>(
 /// # assert_eq!(
 /// #     val.without_context(),
 /// #     // The Type in this case is something like a newtype-wrapped [u8; 32]:
-/// #     Value::new(ValueDef::Composite(Composite::Unnamed(vec![
-/// #         Value::new(ValueDef::Composite(Composite::Unnamed(vec![
-/// #             Value::new(ValueDef::Primitive(
-/// #                 Primitive::U8(1)
-/// #             ));
-/// #             32
-/// #         ])))
-/// #    ])))
+/// #     Value::unnamed_composite(vec![
+/// #         Value::unnamed_composite(vec![Value::u8(1); 32])
+/// #     ])
 /// # );
 /// ```
 pub fn decode_storage(metadata: &Metadata) -> StorageDecoder {

--- a/desub-current/src/decoder/mod.rs
+++ b/desub-current/src/decoder/mod.rs
@@ -384,6 +384,7 @@ pub fn decode_signature<'a>(metadata: &'a Metadata, data: &mut &[u8]) -> Result<
 /// Decode the signed extensions part of a SCALE encoded extrinsic.
 ///
 /// Ordinarily, one should prefer to use [`decode_extrinsic`] directly to decode the entire extrinsic at once.
+#[allow(clippy::type_complexity)]
 pub fn decode_signed_extensions<'a>(
 	metadata: &'a Metadata,
 	data: &mut &[u8],
@@ -403,6 +404,7 @@ pub fn decode_signed_extensions<'a>(
 /// Decode the additional signed data.
 ///
 /// Ordinarily, one should prefer to use [`decode_signer_payload`], to decode the entire signer payload at once.
+#[allow(clippy::type_complexity)]
 pub fn decode_additional_signed<'a>(
 	metadata: &'a Metadata,
 	data: &mut &[u8],

--- a/desub-current/src/decoder/mod.rs
+++ b/desub-current/src/decoder/mod.rs
@@ -430,7 +430,7 @@ pub fn decode_additional_signed<'a>(
 /// Values. We can serialize this for any value of `T`, but we can only
 /// deserialize when `T = ()`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(bound = "Value<T>: serde::de::DeserializeOwned")]
+#[serde(bound(deserialize = "Value<T>: serde::de::DeserializeOwned"))]
 pub struct CallData<'a, T> {
 	/// The name of the pallet
 	#[serde(borrow)]
@@ -465,7 +465,7 @@ impl<'a, T> CallData<'a, T> {
 /// Values. We can serialize this for any value of `T`, but we can only
 /// deserialize when `T = ()`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(bound = "Value<T>: serde::de::DeserializeOwned")]
+#[serde(bound(deserialize = "Value<T>: serde::de::DeserializeOwned"))]
 pub struct Extrinsic<'a, T> {
 	/// Decoded call data and associated type information about the call.
 	#[serde(borrow)]
@@ -493,7 +493,7 @@ impl<'a, T> Extrinsic<'a, T> {
 /// Values. We can serialize this for any value of `T`, but we can only
 /// deserialize when `T = ()`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(bound = "Value<T>: serde::de::DeserializeOwned")]
+#[serde(bound(deserialize = "Value<T>: serde::de::DeserializeOwned"))]
 pub struct ExtrinsicSignature<'a, T> {
 	/// Address the extrinsic is being sent from
 	#[serde(with = "desub_common::RemoteAddress")]
@@ -529,7 +529,7 @@ impl<'a, T> ExtrinsicSignature<'a, T> {
 /// Values. We can serialize this for any value of `T`, but we can only
 /// deserialize when `T = ()`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(bound = "Value<T>: serde::de::DeserializeOwned")]
+#[serde(bound(deserialize = "Value<T>: serde::de::DeserializeOwned"))]
 pub struct SignerPayload<'a, T> {
 	/// Decoded call data and associated type information about the call.
 	#[serde(borrow)]
@@ -560,7 +560,7 @@ impl<'a, T> SignerPayload<'a, T> {
 /// Values. We can serialize this for any value of `T`, but we can only
 /// deserialize when `T = ()`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
-#[serde(bound = "Value<T>: serde::de::DeserializeOwned")]
+#[serde(bound(deserialize = "Value<T>: serde::de::DeserializeOwned"))]
 pub struct SignedExtensionWithAdditional<T> {
 	/// The signed extension value at this position
 	pub extension: Value<T>,

--- a/desub-current/src/lib.rs
+++ b/desub-current/src/lib.rs
@@ -24,7 +24,7 @@ pub mod metadata;
 pub mod value;
 
 pub use metadata::Metadata;
-pub use value::{ Value, ValueDef };
+pub use value::{Value, ValueDef};
 
 pub use type_id::TypeId;
 

--- a/desub-current/src/lib.rs
+++ b/desub-current/src/lib.rs
@@ -17,12 +17,16 @@
 //! A crate to decode extrinsics, signer payloads and storage keys for substrate nodes using V14+ metadata.
 //! See [`decoder`] for more information.
 
+mod type_id;
+
 pub mod decoder;
 pub mod metadata;
 pub mod value;
 
 pub use metadata::Metadata;
-pub use value::Value;
+pub use value::{ Value, ValueDef };
+
+pub use type_id::TypeId;
 
 /// A re-export of the [`scale_info`] crate, since we delegate much of the type inspection to it.
 pub use scale_info;
@@ -30,5 +34,5 @@ pub use scale_info;
 /// A re-export of [`scale_info::Type`] as used throughout this library.
 pub type Type = scale_info::Type<scale_info::form::PortableForm>;
 
-/// A re-export of the [`scale_info`] type ID as used throughout this library.
-pub type TypeId = <scale_info::form::PortableForm as scale_info::form::Form>::Type;
+/// The [`scale_info`] type ID as used throughout this library.
+type ScaleInfoTypeId = scale_info::interner::UntrackedSymbol<std::any::TypeId>; // equivalent to: <scale_info::form::PortableForm as scale_info::form::Form>::Type;

--- a/desub-current/src/metadata/mod.rs
+++ b/desub-current/src/metadata/mod.rs
@@ -21,12 +21,12 @@ mod readonly_array;
 mod u8_map;
 mod version_14;
 
+use crate::{ScaleInfoTypeId, Type, TypeId};
 use codec::Decode;
 use frame_metadata::{RuntimeMetadata, RuntimeMetadataPrefixed};
 use readonly_array::ReadonlyArray;
 use scale_info::{form::PortableForm, PortableRegistry};
 use u8_map::U8Map;
-use crate::{ ScaleInfoTypeId, TypeId, Type };
 
 // Some type aliases used below. `scale-info` is re-exported at the root,
 // so to avoid confusion we only publicly export all scale-info types from that

--- a/desub-current/src/type_id.rs
+++ b/desub-current/src/type_id.rs
@@ -1,0 +1,51 @@
+// Copyright 2019-2021 Parity Technologies (UK) Ltd.
+// This file is part of substrate-desub.
+//
+// substrate-desub is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// substrate-desub is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with substrate-desub.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::ScaleInfoTypeId;
+
+/// This represents the ID of a type found in the metadata. A scale info type representation can
+/// be converted into this, and we get this back directly when decoding types into Values.
+#[derive(Copy,Clone,Debug,PartialEq,Eq,PartialOrd,Ord,Hash,serde::Serialize,serde::Deserialize)]
+pub struct TypeId(u32);
+
+impl TypeId {
+    /// Create a new `TypeId` from a `u32`.
+    pub(crate) fn from_u32(id: u32) -> TypeId {
+        TypeId(id)
+    }
+    /// Return the u32 ID expected by a PortableRegistry.
+    pub(crate) fn id(self) -> u32 {
+        self.0
+    }
+}
+
+impl From<ScaleInfoTypeId> for TypeId {
+    fn from(id: ScaleInfoTypeId) -> Self {
+        TypeId(id.id())
+    }
+}
+
+impl From<&ScaleInfoTypeId> for TypeId {
+    fn from(id: &ScaleInfoTypeId) -> Self {
+        TypeId(id.id())
+    }
+}
+
+impl From<&TypeId> for TypeId {
+    fn from(id: &TypeId) -> Self {
+        *id
+    }
+}

--- a/desub-current/src/type_id.rs
+++ b/desub-current/src/type_id.rs
@@ -18,34 +18,34 @@ use crate::ScaleInfoTypeId;
 
 /// This represents the ID of a type found in the metadata. A scale info type representation can
 /// be converted into this, and we get this back directly when decoding types into Values.
-#[derive(Copy,Clone,Debug,PartialEq,Eq,PartialOrd,Ord,Hash,serde::Serialize,serde::Deserialize)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize)]
 pub struct TypeId(u32);
 
 impl TypeId {
-    /// Create a new `TypeId` from a `u32`.
-    pub(crate) fn from_u32(id: u32) -> TypeId {
-        TypeId(id)
-    }
-    /// Return the u32 ID expected by a PortableRegistry.
-    pub(crate) fn id(self) -> u32 {
-        self.0
-    }
+	/// Create a new `TypeId` from a `u32`.
+	pub(crate) fn from_u32(id: u32) -> TypeId {
+		TypeId(id)
+	}
+	/// Return the u32 ID expected by a PortableRegistry.
+	pub(crate) fn id(self) -> u32 {
+		self.0
+	}
 }
 
 impl From<ScaleInfoTypeId> for TypeId {
-    fn from(id: ScaleInfoTypeId) -> Self {
-        TypeId(id.id())
-    }
+	fn from(id: ScaleInfoTypeId) -> Self {
+		TypeId(id.id())
+	}
 }
 
 impl From<&ScaleInfoTypeId> for TypeId {
-    fn from(id: &ScaleInfoTypeId) -> Self {
-        TypeId(id.id())
-    }
+	fn from(id: &ScaleInfoTypeId) -> Self {
+		TypeId(id.id())
+	}
 }
 
 impl From<&TypeId> for TypeId {
-    fn from(id: &TypeId) -> Self {
-        *id
-    }
+	fn from(id: &TypeId) -> Self {
+		*id
+	}
 }

--- a/desub-current/src/value/deserialize.rs
+++ b/desub-current/src/value/deserialize.rs
@@ -86,6 +86,17 @@ impl<'de> Deserialize<'de> for Variant<()> {
 
 struct PrimitiveVisitor;
 
+macro_rules! visit_prim {
+	($name:ident $ty:ident $variant:ident) => {
+		fn $name<E>(self, v: $ty) -> Result<Self::Value, E>
+		where
+			E: serde::de::Error,
+		{
+			Ok(Primitive::$variant(v))
+		}
+	}
+}
+
 impl<'de> Visitor<'de> for PrimitiveVisitor {
 	type Value = Primitive;
 
@@ -93,89 +104,18 @@ impl<'de> Visitor<'de> for PrimitiveVisitor {
 		formatter.write_str("a type that can be decoded into a Primitive value")
 	}
 
-	fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
-	where
-		E: serde::de::Error,
-	{
-		Ok(Primitive::Bool(v))
-	}
-
-	fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
-	where
-		E: serde::de::Error,
-	{
-		Ok(Primitive::I8(v))
-	}
-
-	fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
-	where
-		E: serde::de::Error,
-	{
-		Ok(Primitive::I16(v))
-	}
-
-	fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
-	where
-		E: serde::de::Error,
-	{
-		Ok(Primitive::I32(v))
-	}
-
-	fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
-	where
-		E: serde::de::Error,
-	{
-		Ok(Primitive::I64(v))
-	}
-
-	fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
-	where
-		E: serde::de::Error,
-	{
-		Ok(Primitive::I128(v))
-	}
-
-	fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
-	where
-		E: serde::de::Error,
-	{
-		Ok(Primitive::U8(v))
-	}
-
-	fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
-	where
-		E: serde::de::Error,
-	{
-		Ok(Primitive::U16(v))
-	}
-
-	fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
-	where
-		E: serde::de::Error,
-	{
-		Ok(Primitive::U32(v))
-	}
-
-	fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
-	where
-		E: serde::de::Error,
-	{
-		Ok(Primitive::U64(v))
-	}
-
-	fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
-	where
-		E: serde::de::Error,
-	{
-		Ok(Primitive::U128(v))
-	}
-
-	fn visit_char<E>(self, v: char) -> Result<Self::Value, E>
-	where
-		E: serde::de::Error,
-	{
-		Ok(Primitive::Char(v))
-	}
+	visit_prim!(visit_bool bool Bool);
+	visit_prim!(visit_i8 i8 I8);
+	visit_prim!(visit_i16 i16 I16);
+	visit_prim!(visit_i32 i32 I32);
+	visit_prim!(visit_i64 i64 I64);
+	visit_prim!(visit_i128 i128 I128);
+	visit_prim!(visit_u8 u8 U8);
+	visit_prim!(visit_u16 u16 U16);
+	visit_prim!(visit_u32 u32 U32);
+	visit_prim!(visit_u64 u64 U64);
+	visit_prim!(visit_u128 u128 U128);
+	visit_prim!(visit_char char Char);
 
 	fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
 	where

--- a/desub-current/src/value/deserialize.rs
+++ b/desub-current/src/value/deserialize.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-desub.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::{Composite, Primitive, Value, Variant};
+use super::{Composite, Primitive, Value, ValueDef, Variant};
 use serde::{
 	self,
 	de::{Error, Visitor},
@@ -38,12 +38,22 @@ only part of our input into a struct, say, and leave the rest as [`Value`] types
 to do with them.
 */
 
-impl<'de> Deserialize<'de> for Value {
+impl<'de> Deserialize<'de> for Value<()> {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: serde::Deserializer<'de>,
 	{
-		deserializer.deserialize_any(ValueVisitor)
+		let value = deserializer.deserialize_any(ValueDefVisitor)?;
+		Ok(Value { value, context: () })
+	}
+}
+
+impl<'de> Deserialize<'de> for ValueDef<()> {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		deserializer.deserialize_any(ValueDefVisitor)
 	}
 }
 
@@ -56,7 +66,7 @@ impl<'de> Deserialize<'de> for Primitive {
 	}
 }
 
-impl<'de> Deserialize<'de> for Composite {
+impl<'de> Deserialize<'de> for Composite<()> {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: serde::Deserializer<'de>,
@@ -65,7 +75,7 @@ impl<'de> Deserialize<'de> for Composite {
 	}
 }
 
-impl<'de> Deserialize<'de> for Variant {
+impl<'de> Deserialize<'de> for Variant<()> {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: serde::Deserializer<'de>,
@@ -213,7 +223,7 @@ impl<'de> Visitor<'de> for PrimitiveVisitor {
 struct CompositeVisitor;
 
 impl<'de> Visitor<'de> for CompositeVisitor {
-	type Value = Composite;
+	type Value = Composite<()>;
 
 	fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
 		formatter.write_str("a type that can be decoded into a Composite value")
@@ -223,7 +233,7 @@ impl<'de> Visitor<'de> for CompositeVisitor {
 	where
 		E: serde::de::Error,
 	{
-		let byte_values = v.iter().map(|&b| Value::Primitive(Primitive::U8(b))).collect();
+		let byte_values = v.iter().map(|&b| Value::new(ValueDef::Primitive(Primitive::U8(b)))).collect();
 		Ok(Composite::Unnamed(byte_values))
 	}
 
@@ -281,7 +291,7 @@ impl<'de> Visitor<'de> for CompositeVisitor {
 struct VariantVisitor;
 
 impl<'de> Visitor<'de> for VariantVisitor {
-	type Value = Variant;
+	type Value = Variant<()>;
 
 	fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
 		formatter.write_str("a type that can be decoded into an enum Variant")
@@ -333,7 +343,7 @@ impl<'de> Visitor<'de> for VariantVisitor {
 	}
 }
 
-struct ValueVisitor;
+struct ValueDefVisitor;
 
 // It gets repetitive writing out the visitor impls to delegate to the Value subtypes;
 // this helper makes that a little easier:
@@ -351,15 +361,15 @@ macro_rules! delegate_visitor_fn {
 	}
 }
 
-impl<'de> Visitor<'de> for ValueVisitor {
-	type Value = Value;
+impl<'de> Visitor<'de> for ValueDefVisitor {
+	type Value = ValueDef<()>;
 
 	fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
 		formatter.write_str("a type that can be decoded into a Value")
 	}
 
 	delegate_visitor_fn!(
-		PrimitiveVisitor Value::Primitive,
+		PrimitiveVisitor ValueDef::Primitive,
 		visit_bool(bool)
 		visit_i8(i8)
 		visit_i16(i16)
@@ -377,7 +387,7 @@ impl<'de> Visitor<'de> for ValueVisitor {
 	);
 
 	delegate_visitor_fn!(
-		CompositeVisitor Value::Composite,
+		CompositeVisitor ValueDef::Composite,
 		visit_none()
 		visit_unit()
 		visit_bytes(&[u8])
@@ -387,35 +397,35 @@ impl<'de> Visitor<'de> for ValueVisitor {
 	where
 		D: serde::Deserializer<'de>,
 	{
-		Value::deserialize(deserializer)
+		ValueDef::deserialize(deserializer)
 	}
 
 	fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
 	where
 		D: serde::Deserializer<'de>,
 	{
-		Value::deserialize(deserializer)
+		ValueDef::deserialize(deserializer)
 	}
 
 	fn visit_seq<A>(self, seq: A) -> Result<Self::Value, A::Error>
 	where
 		A: serde::de::SeqAccess<'de>,
 	{
-		CompositeVisitor.visit_seq(seq).map(Value::Composite)
+		CompositeVisitor.visit_seq(seq).map(ValueDef::Composite)
 	}
 
 	fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
 	where
 		A: serde::de::MapAccess<'de>,
 	{
-		CompositeVisitor.visit_map(map).map(Value::Composite)
+		CompositeVisitor.visit_map(map).map(ValueDef::Composite)
 	}
 
 	fn visit_enum<A>(self, data: A) -> Result<Self::Value, A::Error>
 	where
 		A: serde::de::EnumAccess<'de>,
 	{
-		VariantVisitor.visit_enum(data).map(Value::Variant)
+		VariantVisitor.visit_enum(data).map(ValueDef::Variant)
 	}
 }
 
@@ -444,42 +454,42 @@ mod test {
 
 	#[test]
 	fn deserialize_primitives_isomorphic() {
-		assert_value_isomorphic(Value::Primitive(Primitive::U8(123)));
-		assert_value_isomorphic(Value::Primitive(Primitive::U16(123)));
-		assert_value_isomorphic(Value::Primitive(Primitive::U32(123)));
-		assert_value_isomorphic(Value::Primitive(Primitive::U64(123)));
-		assert_value_isomorphic(Value::Primitive(Primitive::U128(123)));
-		assert_value_isomorphic(Value::Primitive(Primitive::I8(123)));
-		assert_value_isomorphic(Value::Primitive(Primitive::I16(123)));
-		assert_value_isomorphic(Value::Primitive(Primitive::I32(123)));
-		assert_value_isomorphic(Value::Primitive(Primitive::I64(123)));
-		assert_value_isomorphic(Value::Primitive(Primitive::I128(123)));
-		assert_value_isomorphic(Value::Primitive(Primitive::Bool(true)));
-		assert_value_isomorphic(Value::Primitive(Primitive::Char('a')));
-		assert_value_isomorphic(Value::Primitive(Primitive::Str("Hello!".into())));
+		assert_value_isomorphic(ValueDef::Primitive(Primitive::U8(123)));
+		assert_value_isomorphic(ValueDef::Primitive(Primitive::U16(123)));
+		assert_value_isomorphic(ValueDef::Primitive(Primitive::U32(123)));
+		assert_value_isomorphic(ValueDef::Primitive(Primitive::U64(123)));
+		assert_value_isomorphic(ValueDef::Primitive(Primitive::U128(123)));
+		assert_value_isomorphic(ValueDef::Primitive(Primitive::I8(123)));
+		assert_value_isomorphic(ValueDef::Primitive(Primitive::I16(123)));
+		assert_value_isomorphic(ValueDef::Primitive(Primitive::I32(123)));
+		assert_value_isomorphic(ValueDef::Primitive(Primitive::I64(123)));
+		assert_value_isomorphic(ValueDef::Primitive(Primitive::I128(123)));
+		assert_value_isomorphic(ValueDef::Primitive(Primitive::Bool(true)));
+		assert_value_isomorphic(ValueDef::Primitive(Primitive::Char('a')));
+		assert_value_isomorphic(ValueDef::Primitive(Primitive::Str("Hello!".into())));
 
 		// Alas, I256 and U256 are both a sequence of bytes, which could equally be represented
 		// by a composite sequence (as other sequences-of-things are). We could have a special case where
 		// precisely 32 u8's is deserialized to one of U256 or I256, but for now we use our more general
 		// composite type as the sequence catch-all:
 		assert_value_to_value(
-			Value::Primitive(Primitive::I256([1; 32])),
-			Value::Composite(Composite::Unnamed(
-				vec![1; 32].into_iter().map(|b| Value::Primitive(Primitive::U8(b))).collect(),
+			ValueDef::<()>::Primitive(Primitive::I256([1; 32])),
+			ValueDef::Composite(Composite::Unnamed(
+				vec![1; 32].into_iter().map(|b| Value::new(ValueDef::Primitive(Primitive::U8(b)))).collect(),
 			)),
 		);
 		assert_value_to_value(
-			Value::Primitive(Primitive::U256([1; 32])),
-			Value::Composite(Composite::Unnamed(
-				vec![1; 32].into_iter().map(|b| Value::Primitive(Primitive::U8(b))).collect(),
+			ValueDef::<()>::Primitive(Primitive::U256([1; 32])),
+			ValueDef::Composite(Composite::Unnamed(
+				vec![1; 32].into_iter().map(|b| Value::new(ValueDef::Primitive(Primitive::U8(b)))).collect(),
 			)),
 		);
 
 		// .. that said; if you want a primitive value back, you can use that type directly to get it
 		// (as long as we are given exactly 32 bytes):
 
-		assert_value_to_value(Value::Primitive(Primitive::I256([1; 32])), Primitive::U256([1; 32]));
-		assert_value_to_value(Value::Primitive(Primitive::U256([1; 32])), Primitive::U256([1; 32]));
+		assert_value_to_value(ValueDef::<()>::Primitive(Primitive::I256([1; 32])), Primitive::U256([1; 32]));
+		assert_value_to_value(ValueDef::<()>::Primitive(Primitive::U256([1; 32])), Primitive::U256([1; 32]));
 
 		// Unwrapped versions also work:
 
@@ -501,79 +511,79 @@ mod test {
 
 		// We can also go from wrapped to unwrapped:
 
-		assert_value_to_value(Value::Primitive(Primitive::U8(123)), Primitive::U8(123));
-		assert_value_to_value(Value::Primitive(Primitive::U16(123)), Primitive::U16(123));
-		assert_value_to_value(Value::Primitive(Primitive::U32(123)), Primitive::U32(123));
-		assert_value_to_value(Value::Primitive(Primitive::U64(123)), Primitive::U64(123));
+		assert_value_to_value(ValueDef::<()>::Primitive(Primitive::U8(123)), Primitive::U8(123));
+		assert_value_to_value(ValueDef::<()>::Primitive(Primitive::U16(123)), Primitive::U16(123));
+		assert_value_to_value(ValueDef::<()>::Primitive(Primitive::U32(123)), Primitive::U32(123));
+		assert_value_to_value(ValueDef::<()>::Primitive(Primitive::U64(123)), Primitive::U64(123));
 
 		// Or vice versa:
 
-		assert_value_to_value(Primitive::U8(123), Value::Primitive(Primitive::U8(123)));
-		assert_value_to_value(Primitive::U16(123), Value::Primitive(Primitive::U16(123)));
-		assert_value_to_value(Primitive::U32(123), Value::Primitive(Primitive::U32(123)));
-		assert_value_to_value(Primitive::U64(123), Value::Primitive(Primitive::U64(123)));
+		assert_value_to_value(Primitive::U8(123), ValueDef::Primitive(Primitive::U8(123)));
+		assert_value_to_value(Primitive::U16(123), ValueDef::Primitive(Primitive::U16(123)));
+		assert_value_to_value(Primitive::U32(123), ValueDef::Primitive(Primitive::U32(123)));
+		assert_value_to_value(Primitive::U64(123), ValueDef::Primitive(Primitive::U64(123)));
 	}
 
 	#[test]
 	fn deserialize_composites_isomorphic() {
-		assert_value_isomorphic(Value::Composite(Composite::Unnamed(vec![
-			Value::Primitive(Primitive::U64(123)),
-			Value::Primitive(Primitive::Bool(true)),
+		assert_value_isomorphic(ValueDef::Composite(Composite::Unnamed(vec![
+			Value::new(ValueDef::Primitive(Primitive::U64(123))),
+			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
 		])));
-		assert_value_isomorphic(Value::Composite(Composite::Unnamed(vec![])));
-		assert_value_isomorphic(Value::Composite(Composite::Named(vec![
-			("a".into(), Value::Primitive(Primitive::U64(123))),
-			("b".into(), Value::Primitive(Primitive::Bool(true))),
+		assert_value_isomorphic(ValueDef::Composite(Composite::Unnamed(vec![])));
+		assert_value_isomorphic(ValueDef::Composite(Composite::Named(vec![
+			("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(123)))),
+			("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
 		])));
-		assert_value_isomorphic(Value::Composite(Composite::Named(vec![
-			("a".into(), Value::Primitive(Primitive::U64(123))),
+		assert_value_isomorphic(ValueDef::Composite(Composite::Named(vec![
+			("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(123)))),
 			(
 				"b".into(),
-				Value::Composite(Composite::Named(vec![
-					("c".into(), Value::Primitive(Primitive::U128(123))),
-					("d".into(), Value::Primitive(Primitive::Str("hell".into()))),
-				])),
+				Value::new(ValueDef::Composite(Composite::Named(vec![
+					("c".into(), Value::new(ValueDef::Primitive(Primitive::U128(123)))),
+					("d".into(), Value::new(ValueDef::Primitive(Primitive::Str("hell".into())))),
+				]))),
 			),
 		])));
 
 		// unwrapped:
 
 		assert_value_isomorphic(Composite::Unnamed(vec![
-			Value::Primitive(Primitive::U64(123)),
-			Value::Primitive(Primitive::Bool(true)),
+			Value::new(ValueDef::Primitive(Primitive::U64(123))),
+			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
 		]));
 		assert_value_isomorphic(Composite::Unnamed(vec![]));
 		assert_value_isomorphic(Composite::Named(vec![
-			("a".into(), Value::Primitive(Primitive::U64(123))),
-			("b".into(), Value::Primitive(Primitive::Bool(true))),
+			("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(123)))),
+			("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
 		]));
 		assert_value_isomorphic(Composite::Named(vec![
-			("a".into(), Value::Primitive(Primitive::U64(123))),
+			("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(123)))),
 			(
 				"b".into(),
-				Value::Composite(Composite::Named(vec![
-					("c".into(), Value::Primitive(Primitive::U128(123))),
-					("d".into(), Value::Primitive(Primitive::Str("hell".into()))),
-				])),
+				Value::new(ValueDef::Composite(Composite::Named(vec![
+					("c".into(), Value::new(ValueDef::Primitive(Primitive::U128(123)))),
+					("d".into(), Value::new(ValueDef::Primitive(Primitive::Str("hell".into())))),
+				]))),
 			),
 		]));
 	}
 
 	#[test]
 	fn deserialize_variants_isomorphic() {
-		assert_value_isomorphic(Value::Variant(Variant {
+		assert_value_isomorphic(ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::Primitive(Primitive::U64(123)),
-				Value::Primitive(Primitive::Bool(true)),
+				Value::new(ValueDef::Primitive(Primitive::U64(123))),
+				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
 			]),
 		}));
-		assert_value_isomorphic(Value::Variant(Variant { name: "Foo".into(), values: Composite::Unnamed(vec![]) }));
-		assert_value_isomorphic(Value::Variant(Variant {
+		assert_value_isomorphic(ValueDef::Variant(Variant { name: "Foo".into(), values: Composite::Unnamed(vec![]) }));
+		assert_value_isomorphic(ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("a".into(), Value::Primitive(Primitive::U64(123))),
-				("b".into(), Value::Primitive(Primitive::Bool(true))),
+				("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(123)))),
+				("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
 			]),
 		}));
 
@@ -582,16 +592,16 @@ mod test {
 		assert_value_isomorphic(Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::Primitive(Primitive::U64(123)),
-				Value::Primitive(Primitive::Bool(true)),
+				Value::new(ValueDef::Primitive(Primitive::U64(123))),
+				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
 			]),
 		});
 		assert_value_isomorphic(Variant { name: "Foo".into(), values: Composite::Unnamed(vec![]) });
 		assert_value_isomorphic(Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("a".into(), Value::Primitive(Primitive::U64(123))),
-				("b".into(), Value::Primitive(Primitive::Bool(true))),
+				("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(123)))),
+				("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
 			]),
 		});
 	}
@@ -604,20 +614,20 @@ mod test {
 
 		assert_value_to_value(
 			de.clone(),
-			Value::Composite(Composite::Unnamed(vec![
-				Value::Primitive(Primitive::U8(1)),
-				Value::Primitive(Primitive::U8(2)),
-				Value::Primitive(Primitive::U8(3)),
-				Value::Primitive(Primitive::U8(4)),
+			ValueDef::Composite(Composite::Unnamed(vec![
+				Value::new(ValueDef::Primitive(Primitive::U8(1))),
+				Value::new(ValueDef::Primitive(Primitive::U8(2))),
+				Value::new(ValueDef::Primitive(Primitive::U8(3))),
+				Value::new(ValueDef::Primitive(Primitive::U8(4))),
 			])),
 		);
 		assert_value_to_value(
 			de,
 			Composite::Unnamed(vec![
-				Value::Primitive(Primitive::U8(1)),
-				Value::Primitive(Primitive::U8(2)),
-				Value::Primitive(Primitive::U8(3)),
-				Value::Primitive(Primitive::U8(4)),
+				Value::new(ValueDef::Primitive(Primitive::U8(1))),
+				Value::new(ValueDef::Primitive(Primitive::U8(2))),
+				Value::new(ValueDef::Primitive(Primitive::U8(3))),
+				Value::new(ValueDef::Primitive(Primitive::U8(4))),
 			]),
 		);
 	}
@@ -646,12 +656,12 @@ mod test {
 
 		let de: MapDeserializer<_, DeserializeError> = map.into_deserializer();
 
-		let value = Value::deserialize(de).expect("should deserialize OK");
-		if let Value::Composite(Composite::Named(vals)) = value {
+		let value = ValueDef::deserialize(de).expect("should deserialize OK");
+		if let ValueDef::Composite(Composite::Named(vals)) = value {
 			// These could come back in any order so we need to search for them:
-			assert!(vals.contains(&("a".into(), Value::Primitive(Primitive::I32(1)))));
-			assert!(vals.contains(&("b".into(), Value::Primitive(Primitive::I32(2)))));
-			assert!(vals.contains(&("c".into(), Value::Primitive(Primitive::I32(3)))));
+			assert!(vals.contains(&("a".into(), Value::new(ValueDef::Primitive(Primitive::I32(1))))));
+			assert!(vals.contains(&("b".into(), Value::new(ValueDef::Primitive(Primitive::I32(2))))));
+			assert!(vals.contains(&("c".into(), Value::new(ValueDef::Primitive(Primitive::I32(3))))));
 		} else {
 			panic!("Map should deserialize into Composite::Named value but we have {:?}", value);
 		}
@@ -659,21 +669,21 @@ mod test {
 
 	#[test]
 	fn partially_deserialize_value() {
-		let value = Value::Composite(Composite::Named(vec![
-			("a".into(), Value::Primitive(Primitive::U64(123))),
+		let value = Value::new(ValueDef::Composite(Composite::Named(vec![
+			("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(123)))),
 			(
 				"b".into(),
-				Value::Composite(Composite::Named(vec![
-					("c".into(), Value::Primitive(Primitive::U128(123))),
-					("d".into(), Value::Primitive(Primitive::Str("hell".into()))),
-					("e".into(), Value::Composite(Composite::Unnamed(vec![]))),
-				])),
+				Value::new(ValueDef::Composite(Composite::Named(vec![
+					("c".into(), Value::new(ValueDef::Primitive(Primitive::U128(123)))),
+					("d".into(), Value::new(ValueDef::Primitive(Primitive::Str("hell".into())))),
+					("e".into(), Value::new(ValueDef::Composite(Composite::Unnamed(vec![])))),
+				]))),
 			),
-		]));
+		])));
 
 		#[derive(Deserialize, Debug, PartialEq)]
 		struct Partial {
-			a: Value,
+			a: Value<()>,
 			b: PartialB,
 		}
 
@@ -681,7 +691,7 @@ mod test {
 		struct PartialB {
 			c: u128,
 			d: String,
-			e: Value,
+			e: Value<()>,
 		}
 
 		let partial: Partial = crate::value::from_value(value).expect("should work");
@@ -689,15 +699,15 @@ mod test {
 		assert_eq!(
 			partial,
 			Partial {
-				a: Value::Primitive(Primitive::U64(123)),
-				b: PartialB { c: 123, d: "hell".into(), e: Value::Composite(Composite::Unnamed(vec![])) }
+				a: Value::new(ValueDef::Primitive(Primitive::U64(123))),
+				b: PartialB { c: 123, d: "hell".into(), e: Value::new(ValueDef::Composite(Composite::Unnamed(vec![]))) }
 			}
 		)
 	}
 
 	#[test]
 	fn deserialize_well_formed_map_to_unnamed_variant() {
-		let v: Variant = Variant::deserialize(serde_json::json!({
+		let v: Variant<()> = Variant::deserialize(serde_json::json!({
 			"name": "Hello",
 			"values": [1, 2, true]
 		}))
@@ -708,16 +718,16 @@ mod test {
 			v.values,
 			Composite::Unnamed(vec![
 				// All JSON numbers deserialize to U64 or I64 or F64 as necessary:
-				Value::Primitive(Primitive::U64(1)),
-				Value::Primitive(Primitive::U64(2)),
-				Value::Primitive(Primitive::Bool(true)),
+				Value::new(ValueDef::Primitive(Primitive::U64(1))),
+				Value::new(ValueDef::Primitive(Primitive::U64(2))),
+				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
 			])
 		)
 	}
 
 	#[test]
 	fn deserialize_well_formed_map_to_named_variant() {
-		let v: Variant = Variant::deserialize(serde_json::json!({
+		let v: Variant<()> = Variant::deserialize(serde_json::json!({
 			"name": "Hello",
 			"values": { "a": 1, "b": 2, "c": true }
 		}))
@@ -728,9 +738,9 @@ mod test {
 			v.values,
 			Composite::Named(vec![
 				// All JSON numbers deserialize to U64 or I64 or F64 as necessary:
-				("a".into(), Value::Primitive(Primitive::U64(1))),
-				("b".into(), Value::Primitive(Primitive::U64(2))),
-				("c".into(), Value::Primitive(Primitive::Bool(true))),
+				("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(1)))),
+				("b".into(), Value::new(ValueDef::Primitive(Primitive::U64(2)))),
+				("c".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
 			])
 		)
 	}

--- a/desub-current/src/value/deserialize.rs
+++ b/desub-current/src/value/deserialize.rs
@@ -233,7 +233,7 @@ impl<'de> Visitor<'de> for CompositeVisitor {
 	where
 		E: serde::de::Error,
 	{
-		let byte_values = v.iter().map(|&b| Value::new(ValueDef::Primitive(Primitive::U8(b)))).collect();
+		let byte_values = v.iter().map(|&b| Value::u8(b)).collect();
 		Ok(Composite::Unnamed(byte_values))
 	}
 
@@ -454,19 +454,19 @@ mod test {
 
 	#[test]
 	fn deserialize_primitives_isomorphic() {
-		assert_value_isomorphic(ValueDef::Primitive(Primitive::U8(123)));
-		assert_value_isomorphic(ValueDef::Primitive(Primitive::U16(123)));
-		assert_value_isomorphic(ValueDef::Primitive(Primitive::U32(123)));
-		assert_value_isomorphic(ValueDef::Primitive(Primitive::U64(123)));
-		assert_value_isomorphic(ValueDef::Primitive(Primitive::U128(123)));
-		assert_value_isomorphic(ValueDef::Primitive(Primitive::I8(123)));
-		assert_value_isomorphic(ValueDef::Primitive(Primitive::I16(123)));
-		assert_value_isomorphic(ValueDef::Primitive(Primitive::I32(123)));
-		assert_value_isomorphic(ValueDef::Primitive(Primitive::I64(123)));
-		assert_value_isomorphic(ValueDef::Primitive(Primitive::I128(123)));
-		assert_value_isomorphic(ValueDef::Primitive(Primitive::Bool(true)));
-		assert_value_isomorphic(ValueDef::Primitive(Primitive::Char('a')));
-		assert_value_isomorphic(ValueDef::Primitive(Primitive::Str("Hello!".into())));
+		assert_value_isomorphic(Value::u8(123));
+		assert_value_isomorphic(Value::u16(123));
+		assert_value_isomorphic(Value::u32(123));
+		assert_value_isomorphic(Value::u64(123));
+		assert_value_isomorphic(Value::u128(123));
+		assert_value_isomorphic(Value::i8(123));
+		assert_value_isomorphic(Value::i16(123));
+		assert_value_isomorphic(Value::i32(123));
+		assert_value_isomorphic(Value::i64(123));
+		assert_value_isomorphic(Value::i128(123));
+		assert_value_isomorphic(Value::bool(true));
+		assert_value_isomorphic(Value::char('a'));
+		assert_value_isomorphic(Value::str("Hello!".into()));
 
 		// Alas, I256 and U256 are both a sequence of bytes, which could equally be represented
 		// by a composite sequence (as other sequences-of-things are). We could have a special case where
@@ -474,15 +474,15 @@ mod test {
 		// composite type as the sequence catch-all:
 		assert_value_to_value(
 			ValueDef::<()>::Primitive(Primitive::I256([1; 32])),
-			ValueDef::Composite(Composite::Unnamed(
-				vec![1; 32].into_iter().map(|b| Value::new(ValueDef::Primitive(Primitive::U8(b)))).collect(),
-			)),
+			Value::unnamed_composite(
+				vec![1; 32].into_iter().map(|b| Value::u8(b)).collect(),
+			),
 		);
 		assert_value_to_value(
 			ValueDef::<()>::Primitive(Primitive::U256([1; 32])),
-			ValueDef::Composite(Composite::Unnamed(
-				vec![1; 32].into_iter().map(|b| Value::new(ValueDef::Primitive(Primitive::U8(b)))).collect(),
-			)),
+			Value::unnamed_composite(
+				vec![1; 32].into_iter().map(|b| Value::u8(b)).collect(),
+			),
 		);
 
 		// .. that said; if you want a primitive value back, you can use that type directly to get it
@@ -511,60 +511,60 @@ mod test {
 
 		// We can also go from wrapped to unwrapped:
 
-		assert_value_to_value(ValueDef::<()>::Primitive(Primitive::U8(123)), Primitive::U8(123));
-		assert_value_to_value(ValueDef::<()>::Primitive(Primitive::U16(123)), Primitive::U16(123));
-		assert_value_to_value(ValueDef::<()>::Primitive(Primitive::U32(123)), Primitive::U32(123));
-		assert_value_to_value(ValueDef::<()>::Primitive(Primitive::U64(123)), Primitive::U64(123));
+		assert_value_to_value(Value::u8(123), Primitive::U8(123));
+		assert_value_to_value(Value::u16(123), Primitive::U16(123));
+		assert_value_to_value(Value::u32(123), Primitive::U32(123));
+		assert_value_to_value(Value::u64(123), Primitive::U64(123));
 
 		// Or vice versa:
 
-		assert_value_to_value(Primitive::U8(123), ValueDef::Primitive(Primitive::U8(123)));
-		assert_value_to_value(Primitive::U16(123), ValueDef::Primitive(Primitive::U16(123)));
-		assert_value_to_value(Primitive::U32(123), ValueDef::Primitive(Primitive::U32(123)));
-		assert_value_to_value(Primitive::U64(123), ValueDef::Primitive(Primitive::U64(123)));
+		assert_value_to_value(Primitive::U8(123), Value::u8(123));
+		assert_value_to_value(Primitive::U16(123), Value::u16(123));
+		assert_value_to_value(Primitive::U32(123), Value::u32(123));
+		assert_value_to_value(Primitive::U64(123), Value::u64(123));
 	}
 
 	#[test]
 	fn deserialize_composites_isomorphic() {
-		assert_value_isomorphic(ValueDef::Composite(Composite::Unnamed(vec![
-			Value::new(ValueDef::Primitive(Primitive::U64(123))),
-			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
-		])));
-		assert_value_isomorphic(ValueDef::Composite(Composite::Unnamed(vec![])));
-		assert_value_isomorphic(ValueDef::Composite(Composite::Named(vec![
-			("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(123)))),
-			("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
-		])));
-		assert_value_isomorphic(ValueDef::Composite(Composite::Named(vec![
-			("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(123)))),
+		assert_value_isomorphic(Value::unnamed_composite(vec![
+			Value::u64(123),
+			Value::bool(true),
+		]));
+		assert_value_isomorphic(Value::named_composite(vec![]));
+		assert_value_isomorphic(Value::named_composite(vec![
+			("a".into(), Value::u64(123)),
+			("b".into(), Value::bool(true)),
+		]));
+		assert_value_isomorphic(Value::named_composite(vec![
+			("a".into(), Value::u64(123)),
 			(
 				"b".into(),
-				Value::new(ValueDef::Composite(Composite::Named(vec![
-					("c".into(), Value::new(ValueDef::Primitive(Primitive::U128(123)))),
-					("d".into(), Value::new(ValueDef::Primitive(Primitive::Str("hell".into())))),
-				]))),
+				Value::named_composite(vec![
+					("c".into(), Value::u128(123)),
+					("d".into(), Value::str("hello".into())),
+				]),
 			),
-		])));
+		]));
 
 		// unwrapped:
 
 		assert_value_isomorphic(Composite::Unnamed(vec![
-			Value::new(ValueDef::Primitive(Primitive::U64(123))),
-			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+			Value::u64(123),
+			Value::bool(true),
 		]));
 		assert_value_isomorphic(Composite::Unnamed(vec![]));
 		assert_value_isomorphic(Composite::Named(vec![
-			("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(123)))),
-			("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
+			("a".into(), Value::u64(123)),
+			("b".into(), Value::bool(true)),
 		]));
 		assert_value_isomorphic(Composite::Named(vec![
-			("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(123)))),
+			("a".into(), Value::u64(123)),
 			(
 				"b".into(),
-				Value::new(ValueDef::Composite(Composite::Named(vec![
-					("c".into(), Value::new(ValueDef::Primitive(Primitive::U128(123)))),
-					("d".into(), Value::new(ValueDef::Primitive(Primitive::Str("hell".into())))),
-				]))),
+				Value::named_composite(vec![
+					("c".into(), Value::u128(123)),
+					("d".into(), Value::str("hello".into())),
+				]),
 			),
 		]));
 	}
@@ -574,16 +574,16 @@ mod test {
 		assert_value_isomorphic(ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::new(ValueDef::Primitive(Primitive::U64(123))),
-				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+				Value::u64(123),
+				Value::bool(true),
 			]),
 		}));
 		assert_value_isomorphic(ValueDef::Variant(Variant { name: "Foo".into(), values: Composite::Unnamed(vec![]) }));
 		assert_value_isomorphic(ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(123)))),
-				("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
+				("a".into(), Value::u64(123)),
+				("b".into(), Value::bool(true)),
 			]),
 		}));
 
@@ -592,16 +592,16 @@ mod test {
 		assert_value_isomorphic(Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::new(ValueDef::Primitive(Primitive::U64(123))),
-				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+				Value::u64(123),
+				Value::bool(true),
 			]),
 		});
 		assert_value_isomorphic(Variant { name: "Foo".into(), values: Composite::Unnamed(vec![]) });
 		assert_value_isomorphic(Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(123)))),
-				("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
+				("a".into(), Value::u64(123)),
+				("b".into(), Value::bool(true)),
 			]),
 		});
 	}
@@ -614,20 +614,20 @@ mod test {
 
 		assert_value_to_value(
 			de.clone(),
-			ValueDef::Composite(Composite::Unnamed(vec![
-				Value::new(ValueDef::Primitive(Primitive::U8(1))),
-				Value::new(ValueDef::Primitive(Primitive::U8(2))),
-				Value::new(ValueDef::Primitive(Primitive::U8(3))),
-				Value::new(ValueDef::Primitive(Primitive::U8(4))),
-			])),
+			Value::unnamed_composite(vec![
+				Value::u8(1),
+				Value::u8(2),
+				Value::u8(3),
+				Value::u8(4),
+			]),
 		);
 		assert_value_to_value(
 			de,
 			Composite::Unnamed(vec![
-				Value::new(ValueDef::Primitive(Primitive::U8(1))),
-				Value::new(ValueDef::Primitive(Primitive::U8(2))),
-				Value::new(ValueDef::Primitive(Primitive::U8(3))),
-				Value::new(ValueDef::Primitive(Primitive::U8(4))),
+				Value::u8(1),
+				Value::u8(2),
+				Value::u8(3),
+				Value::u8(4),
 			]),
 		);
 	}
@@ -659,9 +659,9 @@ mod test {
 		let value = ValueDef::deserialize(de).expect("should deserialize OK");
 		if let ValueDef::Composite(Composite::Named(vals)) = value {
 			// These could come back in any order so we need to search for them:
-			assert!(vals.contains(&("a".into(), Value::new(ValueDef::Primitive(Primitive::I32(1))))));
-			assert!(vals.contains(&("b".into(), Value::new(ValueDef::Primitive(Primitive::I32(2))))));
-			assert!(vals.contains(&("c".into(), Value::new(ValueDef::Primitive(Primitive::I32(3))))));
+			assert!(vals.contains(&("a".into(), Value::i32(1))));
+			assert!(vals.contains(&("b".into(), Value::i32(2))));
+			assert!(vals.contains(&("c".into(), Value::i32(3))));
 		} else {
 			panic!("Map should deserialize into Composite::Named value but we have {:?}", value);
 		}
@@ -669,17 +669,17 @@ mod test {
 
 	#[test]
 	fn partially_deserialize_value() {
-		let value = Value::new(ValueDef::Composite(Composite::Named(vec![
-			("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(123)))),
+		let value = Value::named_composite(vec![
+			("a".into(), Value::u64(123)),
 			(
 				"b".into(),
-				Value::new(ValueDef::Composite(Composite::Named(vec![
-					("c".into(), Value::new(ValueDef::Primitive(Primitive::U128(123)))),
-					("d".into(), Value::new(ValueDef::Primitive(Primitive::Str("hell".into())))),
-					("e".into(), Value::new(ValueDef::Composite(Composite::Unnamed(vec![])))),
-				]))),
+				Value::named_composite(vec![
+					("c".into(), Value::u128(123)),
+					("d".into(), Value::str("hello".into())),
+					("e".into(), Value::named_composite(vec![])),
+				]),
 			),
-		])));
+		]);
 
 		#[derive(Deserialize, Debug, PartialEq)]
 		struct Partial {
@@ -699,8 +699,8 @@ mod test {
 		assert_eq!(
 			partial,
 			Partial {
-				a: Value::new(ValueDef::Primitive(Primitive::U64(123))),
-				b: PartialB { c: 123, d: "hell".into(), e: Value::new(ValueDef::Composite(Composite::Unnamed(vec![]))) }
+				a: Value::u64(123),
+				b: PartialB { c: 123, d: "hello".into(), e: Value::named_composite(vec![]) }
 			}
 		)
 	}
@@ -718,9 +718,9 @@ mod test {
 			v.values,
 			Composite::Unnamed(vec![
 				// All JSON numbers deserialize to U64 or I64 or F64 as necessary:
-				Value::new(ValueDef::Primitive(Primitive::U64(1))),
-				Value::new(ValueDef::Primitive(Primitive::U64(2))),
-				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+				Value::u64(1),
+				Value::u64(2),
+				Value::bool(true),
 			])
 		)
 	}
@@ -738,9 +738,9 @@ mod test {
 			v.values,
 			Composite::Named(vec![
 				// All JSON numbers deserialize to U64 or I64 or F64 as necessary:
-				("a".into(), Value::new(ValueDef::Primitive(Primitive::U64(1)))),
-				("b".into(), Value::new(ValueDef::Primitive(Primitive::U64(2)))),
-				("c".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
+				("a".into(), Value::u64(1)),
+				("b".into(), Value::u64(2)),
+				("c".into(), Value::bool(true)),
 			])
 		)
 	}

--- a/desub-current/src/value/deserialize.rs
+++ b/desub-current/src/value/deserialize.rs
@@ -474,15 +474,11 @@ mod test {
 		// composite type as the sequence catch-all:
 		assert_value_to_value(
 			ValueDef::<()>::Primitive(Primitive::I256([1; 32])),
-			Value::unnamed_composite(
-				vec![1; 32].into_iter().map(|b| Value::u8(b)).collect(),
-			),
+			Value::unnamed_composite(vec![1; 32].into_iter().map(|b| Value::u8(b)).collect()),
 		);
 		assert_value_to_value(
 			ValueDef::<()>::Primitive(Primitive::U256([1; 32])),
-			Value::unnamed_composite(
-				vec![1; 32].into_iter().map(|b| Value::u8(b)).collect(),
-			),
+			Value::unnamed_composite(vec![1; 32].into_iter().map(|b| Value::u8(b)).collect()),
 		);
 
 		// .. that said; if you want a primitive value back, you can use that type directly to get it
@@ -526,10 +522,7 @@ mod test {
 
 	#[test]
 	fn deserialize_composites_isomorphic() {
-		assert_value_isomorphic(Value::unnamed_composite(vec![
-			Value::u64(123),
-			Value::bool(true),
-		]));
+		assert_value_isomorphic(Value::unnamed_composite(vec![Value::u64(123), Value::bool(true)]));
 		assert_value_isomorphic(Value::named_composite(vec![]));
 		assert_value_isomorphic(Value::named_composite(vec![
 			("a".into(), Value::u64(123)),
@@ -539,32 +532,20 @@ mod test {
 			("a".into(), Value::u64(123)),
 			(
 				"b".into(),
-				Value::named_composite(vec![
-					("c".into(), Value::u128(123)),
-					("d".into(), Value::str("hello".into())),
-				]),
+				Value::named_composite(vec![("c".into(), Value::u128(123)), ("d".into(), Value::str("hello".into()))]),
 			),
 		]));
 
 		// unwrapped:
 
-		assert_value_isomorphic(Composite::Unnamed(vec![
-			Value::u64(123),
-			Value::bool(true),
-		]));
+		assert_value_isomorphic(Composite::Unnamed(vec![Value::u64(123), Value::bool(true)]));
 		assert_value_isomorphic(Composite::Unnamed(vec![]));
-		assert_value_isomorphic(Composite::Named(vec![
-			("a".into(), Value::u64(123)),
-			("b".into(), Value::bool(true)),
-		]));
+		assert_value_isomorphic(Composite::Named(vec![("a".into(), Value::u64(123)), ("b".into(), Value::bool(true))]));
 		assert_value_isomorphic(Composite::Named(vec![
 			("a".into(), Value::u64(123)),
 			(
 				"b".into(),
-				Value::named_composite(vec![
-					("c".into(), Value::u128(123)),
-					("d".into(), Value::str("hello".into())),
-				]),
+				Value::named_composite(vec![("c".into(), Value::u128(123)), ("d".into(), Value::str("hello".into()))]),
 			),
 		]));
 	}
@@ -573,36 +554,24 @@ mod test {
 	fn deserialize_variants_isomorphic() {
 		assert_value_isomorphic(ValueDef::Variant(Variant {
 			name: "Foo".into(),
-			values: Composite::Unnamed(vec![
-				Value::u64(123),
-				Value::bool(true),
-			]),
+			values: Composite::Unnamed(vec![Value::u64(123), Value::bool(true)]),
 		}));
 		assert_value_isomorphic(ValueDef::Variant(Variant { name: "Foo".into(), values: Composite::Unnamed(vec![]) }));
 		assert_value_isomorphic(ValueDef::Variant(Variant {
 			name: "Foo".into(),
-			values: Composite::Named(vec![
-				("a".into(), Value::u64(123)),
-				("b".into(), Value::bool(true)),
-			]),
+			values: Composite::Named(vec![("a".into(), Value::u64(123)), ("b".into(), Value::bool(true))]),
 		}));
 
 		// unwrapped work as well:
 
 		assert_value_isomorphic(Variant {
 			name: "Foo".into(),
-			values: Composite::Unnamed(vec![
-				Value::u64(123),
-				Value::bool(true),
-			]),
+			values: Composite::Unnamed(vec![Value::u64(123), Value::bool(true)]),
 		});
 		assert_value_isomorphic(Variant { name: "Foo".into(), values: Composite::Unnamed(vec![]) });
 		assert_value_isomorphic(Variant {
 			name: "Foo".into(),
-			values: Composite::Named(vec![
-				("a".into(), Value::u64(123)),
-				("b".into(), Value::bool(true)),
-			]),
+			values: Composite::Named(vec![("a".into(), Value::u64(123)), ("b".into(), Value::bool(true))]),
 		});
 	}
 
@@ -614,22 +583,9 @@ mod test {
 
 		assert_value_to_value(
 			de.clone(),
-			Value::unnamed_composite(vec![
-				Value::u8(1),
-				Value::u8(2),
-				Value::u8(3),
-				Value::u8(4),
-			]),
+			Value::unnamed_composite(vec![Value::u8(1), Value::u8(2), Value::u8(3), Value::u8(4)]),
 		);
-		assert_value_to_value(
-			de,
-			Composite::Unnamed(vec![
-				Value::u8(1),
-				Value::u8(2),
-				Value::u8(3),
-				Value::u8(4),
-			]),
-		);
+		assert_value_to_value(de, Composite::Unnamed(vec![Value::u8(1), Value::u8(2), Value::u8(3), Value::u8(4)]));
 	}
 
 	#[test]

--- a/desub-current/src/value/deserializer.rs
+++ b/desub-current/src/value/deserializer.rs
@@ -543,7 +543,7 @@ impl<'de, T> Deserializer<'de> for Composite<T> {
 		V: de::Visitor<'de>,
 	{
 		// 0 length composite types can be treated as the unit type:
-		if self.len() == 0 {
+		if self.is_empty() {
 			visitor.visit_unit()
 		} else {
 			Err(Error::from_str("Cannot deserialize non-empty Composite into a unit value"))

--- a/desub-current/src/value/deserializer.rs
+++ b/desub-current/src/value/deserializer.rs
@@ -96,212 +96,231 @@ impl<'de, T> Deserializer<'de> for Value<T> {
 	type Error = Error;
 
 	fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_any(visitor)
 	}
 
 	fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_bool(visitor)
 	}
 
 	fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_i8(visitor)
 	}
 
 	fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_i16(visitor)
 	}
 
 	fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_i32(visitor)
 	}
 
 	fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_i64(visitor)
 	}
 
-	fn deserialize_i128<V>(self, visitor:V) ->Result<V::Value,Self::Error>
-		where V:de::Visitor< 'de> {
+	fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_i128(visitor)
 	}
 
 	fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_u8(visitor)
 	}
 
 	fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_u16(visitor)
 	}
 
 	fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_u32(visitor)
 	}
 
 	fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_u64(visitor)
 	}
 
-	fn deserialize_u128<V>(self, visitor:V) ->Result<V::Value,Self::Error>
-		where V:de::Visitor< 'de> {
+	fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_u128(visitor)
 	}
 
 	fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_f32(visitor)
 	}
 
 	fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_f64(visitor)
 	}
 
 	fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_char(visitor)
 	}
 
 	fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_str(visitor)
 	}
 
 	fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_string(visitor)
 	}
 
 	fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_bytes(visitor)
 	}
 
 	fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_byte_buf(visitor)
 	}
 
 	fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_option(visitor)
 	}
 
 	fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_unit(visitor)
 	}
 
-	fn deserialize_unit_struct<V>(
-			self,
-			name: &'static str,
-			visitor: V,
-		) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	fn deserialize_unit_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_unit_struct(name, visitor)
 	}
 
-	fn deserialize_newtype_struct<V>(
-			self,
-			name: &'static str,
-			visitor: V,
-		) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	fn deserialize_newtype_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_newtype_struct(name, visitor)
 	}
 
 	fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_seq(visitor)
 	}
 
 	fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_tuple(len, visitor)
 	}
 
-	fn deserialize_tuple_struct<V>(
-			self,
-			name: &'static str,
-			len: usize,
-			visitor: V,
-		) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	fn deserialize_tuple_struct<V>(self, name: &'static str, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_tuple_struct(name, len, visitor)
 	}
 
 	fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_map(visitor)
 	}
 
 	fn deserialize_struct<V>(
-			self,
-			name: &'static str,
-			fields: &'static [&'static str],
-			visitor: V,
-		) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+		self,
+		name: &'static str,
+		fields: &'static [&'static str],
+		visitor: V,
+	) -> Result<V::Value, Self::Error>
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_struct(name, fields, visitor)
 	}
 
 	fn deserialize_enum<V>(
-			self,
-			name: &'static str,
-			variants: &'static [&'static str],
-			visitor: V,
-		) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+		self,
+		name: &'static str,
+		variants: &'static [&'static str],
+		visitor: V,
+	) -> Result<V::Value, Self::Error>
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_enum(name, variants, visitor)
 	}
 
 	fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_identifier(visitor)
 	}
 
 	fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-		where
-			V: de::Visitor<'de> {
+	where
+		V: de::Visitor<'de>,
+	{
 		self.value.deserialize_ignored_any(visitor)
 	}
-
 }
 
 // Our ValueDef deserializer needs to handle BitSeq itself, but otherwise delegates to
@@ -1179,11 +1198,7 @@ mod test {
 		#[derive(Deserialize, Debug, PartialEq)]
 		struct Foo(u8, bool, String);
 
-		let val = Composite::Unnamed(vec![
-			Value::u8(123),
-			Value::bool(true),
-			Value::str("hello".into()),
-		]);
+		let val = Composite::Unnamed(vec![Value::u8(123), Value::bool(true), Value::str("hello".into())]);
 
 		assert_eq!(Foo::deserialize(val), Ok(Foo(123, true, "hello".into())))
 	}
@@ -1199,11 +1214,7 @@ mod test {
 
 		#[derive(Deserialize, Debug, PartialEq)]
 		struct FooVecU8(Vec<u8>);
-		let val = ValueDef::Composite(Composite::Unnamed(vec![
-			Value::u8(1),
-			Value::u8(2),
-			Value::u8(3),
-		]));
+		let val = ValueDef::Composite(Composite::Unnamed(vec![Value::u8(1), Value::u8(2), Value::u8(3)]));
 		assert_eq!(FooVecU8::deserialize(val), Ok(FooVecU8(vec![1, 2, 3])));
 
 		#[derive(Deserialize, Debug, PartialEq)]
@@ -1214,11 +1225,7 @@ mod test {
 		struct FooVar(MyEnum);
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
-			values: Composite::Unnamed(vec![
-				Value::u8(1),
-				Value::u8(2),
-				Value::u8(3),
-			]),
+			values: Composite::Unnamed(vec![Value::u8(1), Value::u8(2), Value::u8(3)]),
 		});
 		assert_eq!(FooVar::deserialize(val), Ok(FooVar(MyEnum::Foo(1, 2, 3))));
 	}
@@ -1232,11 +1239,7 @@ mod test {
 
 		#[derive(Deserialize, Debug, PartialEq)]
 		struct FooVecU8(Vec<u8>);
-		let val = Composite::Unnamed(vec![
-			Value::u8(1),
-			Value::u8(2),
-			Value::u8(3),
-		]);
+		let val = Composite::Unnamed(vec![Value::u8(1), Value::u8(2), Value::u8(3)]);
 		assert_eq!(FooVecU8::deserialize(val), Ok(FooVecU8(vec![1, 2, 3])));
 
 		#[derive(Deserialize, Debug, PartialEq)]
@@ -1245,24 +1248,14 @@ mod test {
 		}
 		#[derive(Deserialize, Debug, PartialEq)]
 		struct FooVar(MyEnum);
-		let val = Variant {
-			name: "Foo".into(),
-			values: Composite::Unnamed(vec![
-				Value::u8(1),
-				Value::u8(2),
-				Value::u8(3),
-			]),
-		};
+		let val =
+			Variant { name: "Foo".into(), values: Composite::Unnamed(vec![Value::u8(1), Value::u8(2), Value::u8(3)]) };
 		assert_eq!(FooVar::deserialize(val), Ok(FooVar(MyEnum::Foo(1, 2, 3))));
 	}
 
 	#[test]
 	fn de_into_vec() {
-		let val = ValueDef::Composite(Composite::Unnamed(vec![
-			Value::u8(1),
-			Value::u8(2),
-			Value::u8(3),
-		]));
+		let val = ValueDef::Composite(Composite::Unnamed(vec![Value::u8(1), Value::u8(2), Value::u8(3)]));
 		assert_eq!(<Vec<u8>>::deserialize(val), Ok(vec![1, 2, 3]));
 
 		let val = ValueDef::Composite(Composite::Unnamed(vec![
@@ -1275,25 +1268,14 @@ mod test {
 
 	#[test]
 	fn de_unwrapped_into_vec() {
-		let val = Composite::Unnamed(vec![
-			Value::u8(1),
-			Value::u8(2),
-			Value::u8(3),
-		]);
+		let val = Composite::Unnamed(vec![Value::u8(1), Value::u8(2), Value::u8(3)]);
 		assert_eq!(<Vec<u8>>::deserialize(val), Ok(vec![1, 2, 3]));
 
-		let val = Composite::Named(vec![
-			("a".into(), Value::u8(1)),
-			("b".into(), Value::u8(2)),
-			("c".into(), Value::u8(3)),
-		]);
+		let val =
+			Composite::Named(vec![("a".into(), Value::u8(1)), ("b".into(), Value::u8(2)), ("c".into(), Value::u8(3))]);
 		assert_eq!(<Vec<u8>>::deserialize(val), Ok(vec![1, 2, 3]));
 
-		let val = Composite::Unnamed(vec![
-			Value::str("a".into()),
-			Value::str("b".into()),
-			Value::str("c".into()),
-		]);
+		let val = Composite::Unnamed(vec![Value::str("a".into()), Value::str("b".into()), Value::str("c".into())]);
 		assert_eq!(<Vec<String>>::deserialize(val), Ok(vec!["a".into(), "b".into(), "c".into()]));
 	}
 
@@ -1311,20 +1293,13 @@ mod test {
 			Ok(vec![("a".into(), 1), ("b".into(), 2), ("c".into(), 3)].into_iter().collect())
 		);
 
-		let val = ValueDef::Composite(Composite::Unnamed(vec![
-			Value::u8(1),
-			Value::u8(2),
-			Value::u8(3),
-		]));
+		let val = ValueDef::Composite(Composite::Unnamed(vec![Value::u8(1), Value::u8(2), Value::u8(3)]));
 		<HashMap<String, u8>>::deserialize(val).expect_err("no names; can't be map");
 	}
 
 	#[test]
 	fn de_into_tuple() {
-		let val = ValueDef::Composite(Composite::Unnamed(vec![
-			Value::str("hello".into()),
-			Value::bool(true),
-		]));
+		let val = ValueDef::Composite(Composite::Unnamed(vec![Value::str("hello".into()), Value::bool(true)]));
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
 		// names will just be ignored:
@@ -1337,20 +1312,14 @@ mod test {
 		// Enum variants are allowed! The variant name will be ignored:
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
-			values: Composite::Unnamed(vec![
-				Value::str("hello".into()),
-				Value::bool(true),
-			]),
+			values: Composite::Unnamed(vec![Value::str("hello".into()), Value::bool(true)]),
 		});
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
 		// Enum variants with names values are allowed! The variant name will be ignored:
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
-			values: Composite::Named(vec![
-				("a".into(), Value::str("hello".into())),
-				("b".into(), Value::bool(true)),
-			]),
+			values: Composite::Named(vec![("a".into(), Value::str("hello".into())), ("b".into(), Value::bool(true))]),
 		});
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
@@ -1365,25 +1334,15 @@ mod test {
 
 	#[test]
 	fn de_unwrapped_into_tuple() {
-		let val = Composite::Unnamed(vec![
-			Value::str("hello".into()),
-			Value::bool(true),
-		]);
+		let val = Composite::Unnamed(vec![Value::str("hello".into()), Value::bool(true)]);
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
 		// names will just be ignored:
-		let val = Composite::Named(vec![
-			("a".into(), Value::str("hello".into())),
-			("b".into(), Value::bool(true)),
-		]);
+		let val = Composite::Named(vec![("a".into(), Value::str("hello".into())), ("b".into(), Value::bool(true))]);
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
 		// Wrong number of values should fail:
-		let val = Composite::Unnamed(vec![
-			Value::str("hello".into()),
-			Value::bool(true),
-			Value::u8(123),
-		]);
+		let val = Composite::Unnamed(vec![Value::str("hello".into()), Value::bool(true), Value::u8(123)]);
 		<(String, bool)>::deserialize(val).expect_err("Wrong length, should err");
 	}
 
@@ -1410,11 +1369,7 @@ mod test {
 
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
-			values: Composite::Unnamed(vec![
-				Value::str("hello".into()),
-				Value::bool(true),
-				Value::u8(123),
-			]),
+			values: Composite::Unnamed(vec![Value::str("hello".into()), Value::bool(true), Value::u8(123)]),
 		});
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo("hello".into(), true, 123)));
 
@@ -1439,11 +1394,7 @@ mod test {
 
 		let val = Variant {
 			name: "Foo".into(),
-			values: Composite::Unnamed(vec![
-				Value::str("hello".into()),
-				Value::bool(true),
-				Value::u8(123),
-			]),
+			values: Composite::Unnamed(vec![Value::str("hello".into()), Value::bool(true), Value::u8(123)]),
 		};
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo("hello".into(), true, 123)));
 
@@ -1481,22 +1432,14 @@ mod test {
 		// No names needed if order is OK:
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
-			values: Composite::Unnamed(vec![
-				Value::str("hello".into()),
-				Value::bool(true),
-				Value::u8(123),
-			]),
+			values: Composite::Unnamed(vec![Value::str("hello".into()), Value::bool(true), Value::u8(123)]),
 		});
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo { hi: "hello".into(), a: true, b: 123 }));
 
 		// Wrong order won't work if no names:
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
-			values: Composite::Unnamed(vec![
-				Value::bool(true),
-				Value::u8(123),
-				Value::str("hello".into()),
-			]),
+			values: Composite::Unnamed(vec![Value::bool(true), Value::u8(123), Value::str("hello".into())]),
 		});
 		MyEnum::deserialize(val).expect_err("Wrong order shouldn't work");
 

--- a/desub-current/src/value/deserializer.rs
+++ b/desub-current/src/value/deserializer.rs
@@ -90,157 +90,48 @@ impl ser::Error for Error {
 	}
 }
 
+/// Spit out the simple deserialize methods to avoid loads of repetition.
+macro_rules! deserialize_x {
+	($fn_name:ident) => {
+		fn $fn_name<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de>,
+		{
+			self.value.$fn_name(visitor)
+		}
+	}
+}
+
 // Our Value type has some context, which we ignore, and some definition, whose deserializer
 // impl we forward to.
 impl<'de, T> Deserializer<'de> for Value<T> {
 	type Error = Error;
 
-	fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_any(visitor)
-	}
-
-	fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_bool(visitor)
-	}
-
-	fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_i8(visitor)
-	}
-
-	fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_i16(visitor)
-	}
-
-	fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_i32(visitor)
-	}
-
-	fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_i64(visitor)
-	}
-
-	fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_i128(visitor)
-	}
-
-	fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_u8(visitor)
-	}
-
-	fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_u16(visitor)
-	}
-
-	fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_u32(visitor)
-	}
-
-	fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_u64(visitor)
-	}
-
-	fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_u128(visitor)
-	}
-
-	fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_f32(visitor)
-	}
-
-	fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_f64(visitor)
-	}
-
-	fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_char(visitor)
-	}
-
-	fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_str(visitor)
-	}
-
-	fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_string(visitor)
-	}
-
-	fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_bytes(visitor)
-	}
-
-	fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_byte_buf(visitor)
-	}
-
-	fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_option(visitor)
-	}
-
-	fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_unit(visitor)
-	}
+	deserialize_x!(deserialize_any);
+	deserialize_x!(deserialize_bool);
+	deserialize_x!(deserialize_i8);
+	deserialize_x!(deserialize_i16);
+	deserialize_x!(deserialize_i32);
+	deserialize_x!(deserialize_i64);
+	deserialize_x!(deserialize_i128);
+	deserialize_x!(deserialize_u8);
+	deserialize_x!(deserialize_u16);
+	deserialize_x!(deserialize_u32);
+	deserialize_x!(deserialize_u64);
+	deserialize_x!(deserialize_u128);
+	deserialize_x!(deserialize_f32);
+	deserialize_x!(deserialize_f64);
+	deserialize_x!(deserialize_char);
+	deserialize_x!(deserialize_str);
+	deserialize_x!(deserialize_string);
+	deserialize_x!(deserialize_bytes);
+	deserialize_x!(deserialize_byte_buf);
+	deserialize_x!(deserialize_option);
+	deserialize_x!(deserialize_unit);
+	deserialize_x!(deserialize_seq);
+	deserialize_x!(deserialize_map);
+	deserialize_x!(deserialize_identifier);
+	deserialize_x!(deserialize_ignored_any);
 
 	fn deserialize_unit_struct<V>(self, name: &'static str, visitor: V) -> Result<V::Value, Self::Error>
 	where
@@ -256,13 +147,6 @@ impl<'de, T> Deserializer<'de> for Value<T> {
 		self.value.deserialize_newtype_struct(name, visitor)
 	}
 
-	fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_seq(visitor)
-	}
-
 	fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
 	where
 		V: de::Visitor<'de>,
@@ -275,13 +159,6 @@ impl<'de, T> Deserializer<'de> for Value<T> {
 		V: de::Visitor<'de>,
 	{
 		self.value.deserialize_tuple_struct(name, len, visitor)
-	}
-
-	fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_map(visitor)
 	}
 
 	fn deserialize_struct<V>(
@@ -306,20 +183,6 @@ impl<'de, T> Deserializer<'de> for Value<T> {
 		V: de::Visitor<'de>,
 	{
 		self.value.deserialize_enum(name, variants, visitor)
-	}
-
-	fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_identifier(visitor)
-	}
-
-	fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
-	where
-		V: de::Visitor<'de>,
-	{
-		self.value.deserialize_ignored_any(visitor)
 	}
 }
 

--- a/desub-current/src/value/deserializer.rs
+++ b/desub-current/src/value/deserializer.rs
@@ -1136,8 +1136,8 @@ mod test {
 
 		let val = ValueDef::Composite(Composite::Named(vec![
 			// Order shouldn't matter; match on names:
-			("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
-			("a".into(), Value::new(ValueDef::Primitive(Primitive::U8(123)))),
+			("b".into(), Value::bool(true)),
+			("a".into(), Value::u8(123)),
 		]));
 
 		assert_eq!(Foo::deserialize(val), Ok(Foo { a: 123, b: true }))
@@ -1153,8 +1153,8 @@ mod test {
 
 		let val = Composite::Named(vec![
 			// Order shouldn't matter; match on names:
-			("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
-			("a".into(), Value::new(ValueDef::Primitive(Primitive::U8(123)))),
+			("b".into(), Value::bool(true)),
+			("a".into(), Value::u8(123)),
 		]);
 
 		assert_eq!(Foo::deserialize(val), Ok(Foo { a: 123, b: true }))
@@ -1166,9 +1166,9 @@ mod test {
 		struct Foo(u8, bool, String);
 
 		let val = ValueDef::Composite(Composite::Unnamed(vec![
-			Value::new(ValueDef::Primitive(Primitive::U8(123))),
-			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
-			Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
+			Value::u8(123),
+			Value::bool(true),
+			Value::str("hello".into()),
 		]));
 
 		assert_eq!(Foo::deserialize(val), Ok(Foo(123, true, "hello".into())))
@@ -1180,9 +1180,9 @@ mod test {
 		struct Foo(u8, bool, String);
 
 		let val = Composite::Unnamed(vec![
-			Value::new(ValueDef::Primitive(Primitive::U8(123))),
-			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
-			Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
+			Value::u8(123),
+			Value::bool(true),
+			Value::str("hello".into()),
 		]);
 
 		assert_eq!(Foo::deserialize(val), Ok(Foo(123, true, "hello".into())))
@@ -1194,15 +1194,15 @@ mod test {
 		struct FooStr(String);
 		let val = ValueDef::<()>::Primitive(Primitive::Str("hello".into()));
 		assert_eq!(FooStr::deserialize(val), Ok(FooStr("hello".into())));
-		let val = Value::new(ValueDef::Primitive(Primitive::Str("hello".into())));
+		let val = Value::str("hello".into());
 		assert_eq!(FooStr::deserialize(val), Ok(FooStr("hello".into())));
 
 		#[derive(Deserialize, Debug, PartialEq)]
 		struct FooVecU8(Vec<u8>);
 		let val = ValueDef::Composite(Composite::Unnamed(vec![
-			Value::new(ValueDef::Primitive(Primitive::U8(1))),
-			Value::new(ValueDef::Primitive(Primitive::U8(2))),
-			Value::new(ValueDef::Primitive(Primitive::U8(3))),
+			Value::u8(1),
+			Value::u8(2),
+			Value::u8(3),
 		]));
 		assert_eq!(FooVecU8::deserialize(val), Ok(FooVecU8(vec![1, 2, 3])));
 
@@ -1215,9 +1215,9 @@ mod test {
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::new(ValueDef::Primitive(Primitive::U8(1))),
-				Value::new(ValueDef::Primitive(Primitive::U8(2))),
-				Value::new(ValueDef::Primitive(Primitive::U8(3))),
+				Value::u8(1),
+				Value::u8(2),
+				Value::u8(3),
 			]),
 		});
 		assert_eq!(FooVar::deserialize(val), Ok(FooVar(MyEnum::Foo(1, 2, 3))));
@@ -1233,9 +1233,9 @@ mod test {
 		#[derive(Deserialize, Debug, PartialEq)]
 		struct FooVecU8(Vec<u8>);
 		let val = Composite::Unnamed(vec![
-			Value::new(ValueDef::Primitive(Primitive::U8(1))),
-			Value::new(ValueDef::Primitive(Primitive::U8(2))),
-			Value::new(ValueDef::Primitive(Primitive::U8(3))),
+			Value::u8(1),
+			Value::u8(2),
+			Value::u8(3),
 		]);
 		assert_eq!(FooVecU8::deserialize(val), Ok(FooVecU8(vec![1, 2, 3])));
 
@@ -1248,9 +1248,9 @@ mod test {
 		let val = Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::new(ValueDef::Primitive(Primitive::U8(1))),
-				Value::new(ValueDef::Primitive(Primitive::U8(2))),
-				Value::new(ValueDef::Primitive(Primitive::U8(3))),
+				Value::u8(1),
+				Value::u8(2),
+				Value::u8(3),
 			]),
 		};
 		assert_eq!(FooVar::deserialize(val), Ok(FooVar(MyEnum::Foo(1, 2, 3))));
@@ -1259,16 +1259,16 @@ mod test {
 	#[test]
 	fn de_into_vec() {
 		let val = ValueDef::Composite(Composite::Unnamed(vec![
-			Value::new(ValueDef::Primitive(Primitive::U8(1))),
-			Value::new(ValueDef::Primitive(Primitive::U8(2))),
-			Value::new(ValueDef::Primitive(Primitive::U8(3))),
+			Value::u8(1),
+			Value::u8(2),
+			Value::u8(3),
 		]));
 		assert_eq!(<Vec<u8>>::deserialize(val), Ok(vec![1, 2, 3]));
 
 		let val = ValueDef::Composite(Composite::Unnamed(vec![
-			Value::new(ValueDef::Primitive(Primitive::Str("a".into()))),
-			Value::new(ValueDef::Primitive(Primitive::Str("b".into()))),
-			Value::new(ValueDef::Primitive(Primitive::Str("c".into()))),
+			Value::str("a".into()),
+			Value::str("b".into()),
+			Value::str("c".into()),
 		]));
 		assert_eq!(<Vec<String>>::deserialize(val), Ok(vec!["a".into(), "b".into(), "c".into()]));
 	}
@@ -1276,23 +1276,23 @@ mod test {
 	#[test]
 	fn de_unwrapped_into_vec() {
 		let val = Composite::Unnamed(vec![
-			Value::new(ValueDef::Primitive(Primitive::U8(1))),
-			Value::new(ValueDef::Primitive(Primitive::U8(2))),
-			Value::new(ValueDef::Primitive(Primitive::U8(3))),
+			Value::u8(1),
+			Value::u8(2),
+			Value::u8(3),
 		]);
 		assert_eq!(<Vec<u8>>::deserialize(val), Ok(vec![1, 2, 3]));
 
 		let val = Composite::Named(vec![
-			("a".into(), Value::new(ValueDef::Primitive(Primitive::U8(1)))),
-			("b".into(), Value::new(ValueDef::Primitive(Primitive::U8(2)))),
-			("c".into(), Value::new(ValueDef::Primitive(Primitive::U8(3)))),
+			("a".into(), Value::u8(1)),
+			("b".into(), Value::u8(2)),
+			("c".into(), Value::u8(3)),
 		]);
 		assert_eq!(<Vec<u8>>::deserialize(val), Ok(vec![1, 2, 3]));
 
 		let val = Composite::Unnamed(vec![
-			Value::new(ValueDef::Primitive(Primitive::Str("a".into()))),
-			Value::new(ValueDef::Primitive(Primitive::Str("b".into()))),
-			Value::new(ValueDef::Primitive(Primitive::Str("c".into()))),
+			Value::str("a".into()),
+			Value::str("b".into()),
+			Value::str("c".into()),
 		]);
 		assert_eq!(<Vec<String>>::deserialize(val), Ok(vec!["a".into(), "b".into(), "c".into()]));
 	}
@@ -1302,9 +1302,9 @@ mod test {
 		use std::collections::HashMap;
 
 		let val = ValueDef::Composite(Composite::Named(vec![
-			("a".into(), Value::new(ValueDef::Primitive(Primitive::U8(1)))),
-			("b".into(), Value::new(ValueDef::Primitive(Primitive::U8(2)))),
-			("c".into(), Value::new(ValueDef::Primitive(Primitive::U8(3)))),
+			("a".into(), Value::u8(1)),
+			("b".into(), Value::u8(2)),
+			("c".into(), Value::u8(3)),
 		]));
 		assert_eq!(
 			<HashMap<String, u8>>::deserialize(val),
@@ -1312,9 +1312,9 @@ mod test {
 		);
 
 		let val = ValueDef::Composite(Composite::Unnamed(vec![
-			Value::new(ValueDef::Primitive(Primitive::U8(1))),
-			Value::new(ValueDef::Primitive(Primitive::U8(2))),
-			Value::new(ValueDef::Primitive(Primitive::U8(3))),
+			Value::u8(1),
+			Value::u8(2),
+			Value::u8(3),
 		]));
 		<HashMap<String, u8>>::deserialize(val).expect_err("no names; can't be map");
 	}
@@ -1322,15 +1322,15 @@ mod test {
 	#[test]
 	fn de_into_tuple() {
 		let val = ValueDef::Composite(Composite::Unnamed(vec![
-			Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
-			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+			Value::str("hello".into()),
+			Value::bool(true),
 		]));
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
 		// names will just be ignored:
 		let val = ValueDef::Composite(Composite::Named(vec![
-			("a".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
-			("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
+			("a".into(), Value::str("hello".into())),
+			("b".into(), Value::bool(true)),
 		]));
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
@@ -1338,8 +1338,8 @@ mod test {
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
-				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+				Value::str("hello".into()),
+				Value::bool(true),
 			]),
 		});
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
@@ -1348,17 +1348,17 @@ mod test {
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("a".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
-				("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
+				("a".into(), Value::str("hello".into())),
+				("b".into(), Value::bool(true)),
 			]),
 		});
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
 		// Wrong number of values should fail:
 		let val = ValueDef::Composite(Composite::Unnamed(vec![
-			Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
-			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
-			Value::new(ValueDef::Primitive(Primitive::U8(123))),
+			Value::str("hello".into()),
+			Value::bool(true),
+			Value::u8(123),
 		]));
 		<(String, bool)>::deserialize(val).expect_err("Wrong length, should err");
 	}
@@ -1366,23 +1366,23 @@ mod test {
 	#[test]
 	fn de_unwrapped_into_tuple() {
 		let val = Composite::Unnamed(vec![
-			Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
-			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+			Value::str("hello".into()),
+			Value::bool(true),
 		]);
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
 		// names will just be ignored:
 		let val = Composite::Named(vec![
-			("a".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
-			("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
+			("a".into(), Value::str("hello".into())),
+			("b".into(), Value::bool(true)),
 		]);
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
 		// Wrong number of values should fail:
 		let val = Composite::Unnamed(vec![
-			Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
-			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
-			Value::new(ValueDef::Primitive(Primitive::U8(123))),
+			Value::str("hello".into()),
+			Value::bool(true),
+			Value::u8(123),
 		]);
 		<(String, bool)>::deserialize(val).expect_err("Wrong length, should err");
 	}
@@ -1391,10 +1391,10 @@ mod test {
 	fn de_bitvec() {
 		use bitvec::{bitvec, order::Lsb0};
 
-		let val = Value::new(ValueDef::BitSequence(bitvec![Lsb0, u8; 0, 1, 1, 0, 1, 0, 1, 0]));
+		let val = Value::bit_sequence(bitvec![Lsb0, u8; 0, 1, 1, 0, 1, 0, 1, 0]);
 		assert_eq!(BitSequence::deserialize(val), Ok(bitvec![Lsb0, u8; 0, 1, 1, 0, 1, 0, 1, 0]));
 
-		let val = Value::new(ValueDef::BitSequence(bitvec![Lsb0, u8; 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0]));
+		let val = Value::bit_sequence(bitvec![Lsb0, u8; 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0]);
 		assert_eq!(
 			BitSequence::deserialize(val),
 			Ok(bitvec![Lsb0, u8; 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0])
@@ -1411,9 +1411,9 @@ mod test {
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
-				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
-				Value::new(ValueDef::Primitive(Primitive::U8(123))),
+				Value::str("hello".into()),
+				Value::bool(true),
+				Value::u8(123),
 			]),
 		});
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo("hello".into(), true, 123)));
@@ -1422,9 +1422,9 @@ mod test {
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("a".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
-				("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
-				("c".into(), Value::new(ValueDef::Primitive(Primitive::U8(123)))),
+				("a".into(), Value::str("hello".into())),
+				("b".into(), Value::bool(true)),
+				("c".into(), Value::u8(123)),
 			]),
 		});
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo("hello".into(), true, 123)));
@@ -1440,9 +1440,9 @@ mod test {
 		let val = Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
-				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
-				Value::new(ValueDef::Primitive(Primitive::U8(123))),
+				Value::str("hello".into()),
+				Value::bool(true),
+				Value::u8(123),
 			]),
 		};
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo("hello".into(), true, 123)));
@@ -1451,9 +1451,9 @@ mod test {
 		let val = Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("a".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
-				("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
-				("c".into(), Value::new(ValueDef::Primitive(Primitive::U8(123)))),
+				("a".into(), Value::str("hello".into())),
+				("b".into(), Value::bool(true)),
+				("c".into(), Value::u8(123)),
 			]),
 		};
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo("hello".into(), true, 123)));
@@ -1471,9 +1471,9 @@ mod test {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
 				// Deliberately out of order: names should ensure alignment:
-				("b".into(), Value::new(ValueDef::Primitive(Primitive::U8(123)))),
-				("a".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
-				("hi".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
+				("b".into(), Value::u8(123)),
+				("a".into(), Value::bool(true)),
+				("hi".into(), Value::str("hello".into())),
 			]),
 		});
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo { hi: "hello".into(), a: true, b: 123 }));
@@ -1482,9 +1482,9 @@ mod test {
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
-				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
-				Value::new(ValueDef::Primitive(Primitive::U8(123))),
+				Value::str("hello".into()),
+				Value::bool(true),
+				Value::u8(123),
 			]),
 		});
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo { hi: "hello".into(), a: true, b: 123 }));
@@ -1493,9 +1493,9 @@ mod test {
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
-				Value::new(ValueDef::Primitive(Primitive::U8(123))),
-				Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
+				Value::bool(true),
+				Value::u8(123),
+				Value::str("hello".into()),
 			]),
 		});
 		MyEnum::deserialize(val).expect_err("Wrong order shouldn't work");
@@ -1504,10 +1504,10 @@ mod test {
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("b".into(), Value::new(ValueDef::Primitive(Primitive::U8(123)))),
+				("b".into(), Value::u8(123)),
 				// Whoops; wrong name:
-				("c".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
-				("hi".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
+				("c".into(), Value::bool(true)),
+				("hi".into(), Value::str("hello".into())),
 			]),
 		});
 		MyEnum::deserialize(val).expect_err("Wrong names shouldn't work");
@@ -1516,11 +1516,11 @@ mod test {
 		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("foo".into(), Value::new(ValueDef::Primitive(Primitive::U8(40)))),
-				("b".into(), Value::new(ValueDef::Primitive(Primitive::U8(123)))),
-				("a".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
-				("bar".into(), Value::new(ValueDef::Primitive(Primitive::Bool(false)))),
-				("hi".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
+				("foo".into(), Value::u8(40)),
+				("b".into(), Value::u8(123)),
+				("a".into(), Value::bool(true)),
+				("bar".into(), Value::bool(false)),
+				("hi".into(), Value::str("hello".into())),
 			]),
 		});
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo { hi: "hello".into(), a: true, b: 123 }));
@@ -1528,7 +1528,7 @@ mod test {
 
 	#[test]
 	fn de_into_unit_variants() {
-		let val = Value::new(ValueDef::Variant(Variant { name: "Foo".into(), values: Composite::Named(vec![]) }));
+		let val = Value::variant("Foo".into(), Composite::Named(vec![]));
 		let unwrapped_val = Variant::<()> { name: "Foo".into(), values: Composite::Named(vec![]) };
 
 		#[derive(Deserialize, Debug, PartialEq)]

--- a/desub-current/src/value/deserializer.rs
+++ b/desub-current/src/value/deserializer.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with substrate-desub.  If not, see <http://www.gnu.org/licenses/>.
 
-use super::{BitSequence, Composite, Primitive, Value, Variant};
+use super::{BitSequence, Composite, Primitive, Value, ValueDef, Variant};
 use serde::{
 	de::{self, EnumAccess, IntoDeserializer, SeqAccess, VariantAccess},
 	forward_to_deserialize_any, ser, Deserialize, Deserializer, Serialize, Serializer,
@@ -90,7 +90,221 @@ impl ser::Error for Error {
 	}
 }
 
-// Our Value trait needs to handle BitSeq itself, but otherwise delegates to
+// Our Value type has some context, which we ignore, and some definition, whose deserializer
+// impl we forward to.
+impl<'de, T> Deserializer<'de> for Value<T> {
+	type Error = Error;
+
+	fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_any(visitor)
+	}
+
+	fn deserialize_bool<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_bool(visitor)
+	}
+
+	fn deserialize_i8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_i8(visitor)
+	}
+
+	fn deserialize_i16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_i16(visitor)
+	}
+
+	fn deserialize_i32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_i32(visitor)
+	}
+
+	fn deserialize_i64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_i64(visitor)
+	}
+
+	fn deserialize_i128<V>(self, visitor:V) ->Result<V::Value,Self::Error>
+		where V:de::Visitor< 'de> {
+		self.value.deserialize_i128(visitor)
+	}
+
+	fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_u8(visitor)
+	}
+
+	fn deserialize_u16<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_u16(visitor)
+	}
+
+	fn deserialize_u32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_u32(visitor)
+	}
+
+	fn deserialize_u64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_u64(visitor)
+	}
+
+	fn deserialize_u128<V>(self, visitor:V) ->Result<V::Value,Self::Error>
+		where V:de::Visitor< 'de> {
+		self.value.deserialize_u128(visitor)
+	}
+
+	fn deserialize_f32<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_f32(visitor)
+	}
+
+	fn deserialize_f64<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_f64(visitor)
+	}
+
+	fn deserialize_char<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_char(visitor)
+	}
+
+	fn deserialize_str<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_str(visitor)
+	}
+
+	fn deserialize_string<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_string(visitor)
+	}
+
+	fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_bytes(visitor)
+	}
+
+	fn deserialize_byte_buf<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_byte_buf(visitor)
+	}
+
+	fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_option(visitor)
+	}
+
+	fn deserialize_unit<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_unit(visitor)
+	}
+
+	fn deserialize_unit_struct<V>(
+			self,
+			name: &'static str,
+			visitor: V,
+		) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_unit_struct(name, visitor)
+	}
+
+	fn deserialize_newtype_struct<V>(
+			self,
+			name: &'static str,
+			visitor: V,
+		) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_newtype_struct(name, visitor)
+	}
+
+	fn deserialize_seq<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_seq(visitor)
+	}
+
+	fn deserialize_tuple<V>(self, len: usize, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_tuple(len, visitor)
+	}
+
+	fn deserialize_tuple_struct<V>(
+			self,
+			name: &'static str,
+			len: usize,
+			visitor: V,
+		) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_tuple_struct(name, len, visitor)
+	}
+
+	fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_map(visitor)
+	}
+
+	fn deserialize_struct<V>(
+			self,
+			name: &'static str,
+			fields: &'static [&'static str],
+			visitor: V,
+		) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_struct(name, fields, visitor)
+	}
+
+	fn deserialize_enum<V>(
+			self,
+			name: &'static str,
+			variants: &'static [&'static str],
+			visitor: V,
+		) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_enum(name, variants, visitor)
+	}
+
+	fn deserialize_identifier<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_identifier(visitor)
+	}
+
+	fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+		where
+			V: de::Visitor<'de> {
+		self.value.deserialize_ignored_any(visitor)
+	}
+
+}
+
+// Our ValueDef deserializer needs to handle BitSeq itself, but otherwise delegates to
 // the inner implementations of things to handle. This macro makes that less repetitive
 // to write by only requiring a bitseq impl.
 macro_rules! delegate_except_bitseq {
@@ -99,16 +313,16 @@ macro_rules! delegate_except_bitseq {
             $seq:pat => $expr:expr
     ) => {
         match $self {
-            Value::BitSequence($seq) => {
+            ValueDef::BitSequence($seq) => {
                 $expr
             },
-            Value::Composite(composite) => {
+            ValueDef::Composite(composite) => {
                 composite.$name( $($arg),* )
             },
-            Value::Variant(variant) => {
+            ValueDef::Variant(variant) => {
                 variant.$name( $($arg),* )
             },
-            Value::Primitive(prim) => {
+            ValueDef::Primitive(prim) => {
                 prim.$name( $($arg),* )
             },
         }
@@ -118,7 +332,7 @@ macro_rules! delegate_except_bitseq {
 // The goal here is simply to forward deserialization methods of interest to
 // the relevant subtype. The exception is our BitSequence type, which doesn't
 // have a sub type to forward to and so is handled here.
-impl<'de> Deserializer<'de> for Value {
+impl<'de, T> Deserializer<'de> for ValueDef<T> {
 	type Error = Error;
 
 	fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -255,14 +469,14 @@ impl<'de> Deserializer<'de> for Value {
 	}
 }
 
-impl<'de> IntoDeserializer<'de, Error> for Value {
-	type Deserializer = Value;
+impl<'de, T> IntoDeserializer<'de, Error> for Value<T> {
+	type Deserializer = Value<T>;
 	fn into_deserializer(self) -> Self::Deserializer {
 		self
 	}
 }
 
-impl<'de> Deserializer<'de> for Composite {
+impl<'de, T> Deserializer<'de> for Composite<T> {
 	type Error = Error;
 
 	fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -359,7 +573,7 @@ impl<'de> Deserializer<'de> for Composite {
 				let bytes = values
 					.into_iter()
 					.map(|(_n, v)| {
-						if let Value::Primitive(Primitive::U8(byte)) = v {
+						if let ValueDef::Primitive(Primitive::U8(byte)) = v.value {
 							Ok(byte)
 						} else {
 							Err(Error::from_str("Cannot deserialize composite that is not entirely U8's into bytes"))
@@ -372,7 +586,7 @@ impl<'de> Deserializer<'de> for Composite {
 				let bytes = values
 					.into_iter()
 					.map(|v| {
-						if let Value::Primitive(Primitive::U8(byte)) = v {
+						if let ValueDef::Primitive(Primitive::U8(byte)) = v.value {
 							Ok(byte)
 						} else {
 							Err(Error::from_str("Cannot deserialize composite that is not entirely U8's into bytes"))
@@ -398,8 +612,8 @@ impl<'de> Deserializer<'de> for Composite {
 	}
 }
 
-impl<'de> IntoDeserializer<'de, Error> for Composite {
-	type Deserializer = Composite;
+impl<'de, T> IntoDeserializer<'de, Error> for Composite<T> {
+	type Deserializer = Composite<T>;
 	fn into_deserializer(self) -> Self::Deserializer {
 		self
 	}
@@ -407,16 +621,16 @@ impl<'de> IntoDeserializer<'de, Error> for Composite {
 
 // Because composite types are used to represent variant fields, we allow
 // variant accesses to be called on it, which just delegate to methods defined above.
-impl<'de> VariantAccess<'de> for Composite {
+impl<'de, T> VariantAccess<'de> for Composite<T> {
 	type Error = Error;
 
 	fn unit_variant(self) -> Result<(), Self::Error> {
 		Deserialize::deserialize(self)
 	}
 
-	fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value, Self::Error>
+	fn newtype_variant_seed<S>(self, seed: S) -> Result<S::Value, Self::Error>
 	where
-		T: de::DeserializeSeed<'de>,
+		S: de::DeserializeSeed<'de>,
 	{
 		seed.deserialize(self)
 	}
@@ -436,7 +650,7 @@ impl<'de> VariantAccess<'de> for Composite {
 	}
 }
 
-impl<'de> Deserializer<'de> for Variant {
+impl<'de, T> Deserializer<'de> for Variant<T> {
 	type Error = Error;
 
 	fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
@@ -527,8 +741,8 @@ impl<'de> Deserializer<'de> for Variant {
 	}
 }
 
-impl<'de> IntoDeserializer<'de, Error> for Variant {
-	type Deserializer = Variant;
+impl<'de, T> IntoDeserializer<'de, Error> for Variant<T> {
+	type Deserializer = Variant<T>;
 	fn into_deserializer(self) -> Self::Deserializer {
 		self
 	}
@@ -537,10 +751,10 @@ impl<'de> IntoDeserializer<'de, Error> for Variant {
 // Variant types can be treated as serde enums. Here we just hand back
 // the pair of name and values, where values is a composite type that impls
 // VariantAccess to actually allow deserializing of those values.
-impl<'de> EnumAccess<'de> for Variant {
+impl<'de, T> EnumAccess<'de> for Variant<T> {
 	type Error = Error;
 
-	type Variant = Composite;
+	type Variant = Composite<T>;
 
 	fn variant_seed<V>(self, seed: V) -> Result<(V::Value, Self::Variant), Self::Error>
 	where
@@ -920,10 +1134,10 @@ mod test {
 			b: bool,
 		}
 
-		let val = Value::Composite(Composite::Named(vec![
+		let val = ValueDef::Composite(Composite::Named(vec![
 			// Order shouldn't matter; match on names:
-			("b".into(), Value::Primitive(Primitive::Bool(true))),
-			("a".into(), Value::Primitive(Primitive::U8(123))),
+			("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
+			("a".into(), Value::new(ValueDef::Primitive(Primitive::U8(123)))),
 		]));
 
 		assert_eq!(Foo::deserialize(val), Ok(Foo { a: 123, b: true }))
@@ -939,8 +1153,8 @@ mod test {
 
 		let val = Composite::Named(vec![
 			// Order shouldn't matter; match on names:
-			("b".into(), Value::Primitive(Primitive::Bool(true))),
-			("a".into(), Value::Primitive(Primitive::U8(123))),
+			("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
+			("a".into(), Value::new(ValueDef::Primitive(Primitive::U8(123)))),
 		]);
 
 		assert_eq!(Foo::deserialize(val), Ok(Foo { a: 123, b: true }))
@@ -951,10 +1165,10 @@ mod test {
 		#[derive(Deserialize, Debug, PartialEq)]
 		struct Foo(u8, bool, String);
 
-		let val = Value::Composite(Composite::Unnamed(vec![
-			Value::Primitive(Primitive::U8(123)),
-			Value::Primitive(Primitive::Bool(true)),
-			Value::Primitive(Primitive::Str("hello".into())),
+		let val = ValueDef::Composite(Composite::Unnamed(vec![
+			Value::new(ValueDef::Primitive(Primitive::U8(123))),
+			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+			Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
 		]));
 
 		assert_eq!(Foo::deserialize(val), Ok(Foo(123, true, "hello".into())))
@@ -966,9 +1180,9 @@ mod test {
 		struct Foo(u8, bool, String);
 
 		let val = Composite::Unnamed(vec![
-			Value::Primitive(Primitive::U8(123)),
-			Value::Primitive(Primitive::Bool(true)),
-			Value::Primitive(Primitive::Str("hello".into())),
+			Value::new(ValueDef::Primitive(Primitive::U8(123))),
+			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+			Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
 		]);
 
 		assert_eq!(Foo::deserialize(val), Ok(Foo(123, true, "hello".into())))
@@ -978,15 +1192,17 @@ mod test {
 	fn de_into_newtype_struct() {
 		#[derive(Deserialize, Debug, PartialEq)]
 		struct FooStr(String);
-		let val = Value::Primitive(Primitive::Str("hello".into()));
+		let val = ValueDef::<()>::Primitive(Primitive::Str("hello".into()));
+		assert_eq!(FooStr::deserialize(val), Ok(FooStr("hello".into())));
+		let val = Value::new(ValueDef::Primitive(Primitive::Str("hello".into())));
 		assert_eq!(FooStr::deserialize(val), Ok(FooStr("hello".into())));
 
 		#[derive(Deserialize, Debug, PartialEq)]
 		struct FooVecU8(Vec<u8>);
-		let val = Value::Composite(Composite::Unnamed(vec![
-			Value::Primitive(Primitive::U8(1)),
-			Value::Primitive(Primitive::U8(2)),
-			Value::Primitive(Primitive::U8(3)),
+		let val = ValueDef::Composite(Composite::Unnamed(vec![
+			Value::new(ValueDef::Primitive(Primitive::U8(1))),
+			Value::new(ValueDef::Primitive(Primitive::U8(2))),
+			Value::new(ValueDef::Primitive(Primitive::U8(3))),
 		]));
 		assert_eq!(FooVecU8::deserialize(val), Ok(FooVecU8(vec![1, 2, 3])));
 
@@ -996,12 +1212,12 @@ mod test {
 		}
 		#[derive(Deserialize, Debug, PartialEq)]
 		struct FooVar(MyEnum);
-		let val = Value::Variant(Variant {
+		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::Primitive(Primitive::U8(1)),
-				Value::Primitive(Primitive::U8(2)),
-				Value::Primitive(Primitive::U8(3)),
+				Value::new(ValueDef::Primitive(Primitive::U8(1))),
+				Value::new(ValueDef::Primitive(Primitive::U8(2))),
+				Value::new(ValueDef::Primitive(Primitive::U8(3))),
 			]),
 		});
 		assert_eq!(FooVar::deserialize(val), Ok(FooVar(MyEnum::Foo(1, 2, 3))));
@@ -1017,9 +1233,9 @@ mod test {
 		#[derive(Deserialize, Debug, PartialEq)]
 		struct FooVecU8(Vec<u8>);
 		let val = Composite::Unnamed(vec![
-			Value::Primitive(Primitive::U8(1)),
-			Value::Primitive(Primitive::U8(2)),
-			Value::Primitive(Primitive::U8(3)),
+			Value::new(ValueDef::Primitive(Primitive::U8(1))),
+			Value::new(ValueDef::Primitive(Primitive::U8(2))),
+			Value::new(ValueDef::Primitive(Primitive::U8(3))),
 		]);
 		assert_eq!(FooVecU8::deserialize(val), Ok(FooVecU8(vec![1, 2, 3])));
 
@@ -1032,9 +1248,9 @@ mod test {
 		let val = Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::Primitive(Primitive::U8(1)),
-				Value::Primitive(Primitive::U8(2)),
-				Value::Primitive(Primitive::U8(3)),
+				Value::new(ValueDef::Primitive(Primitive::U8(1))),
+				Value::new(ValueDef::Primitive(Primitive::U8(2))),
+				Value::new(ValueDef::Primitive(Primitive::U8(3))),
 			]),
 		};
 		assert_eq!(FooVar::deserialize(val), Ok(FooVar(MyEnum::Foo(1, 2, 3))));
@@ -1042,17 +1258,17 @@ mod test {
 
 	#[test]
 	fn de_into_vec() {
-		let val = Value::Composite(Composite::Unnamed(vec![
-			Value::Primitive(Primitive::U8(1)),
-			Value::Primitive(Primitive::U8(2)),
-			Value::Primitive(Primitive::U8(3)),
+		let val = ValueDef::Composite(Composite::Unnamed(vec![
+			Value::new(ValueDef::Primitive(Primitive::U8(1))),
+			Value::new(ValueDef::Primitive(Primitive::U8(2))),
+			Value::new(ValueDef::Primitive(Primitive::U8(3))),
 		]));
 		assert_eq!(<Vec<u8>>::deserialize(val), Ok(vec![1, 2, 3]));
 
-		let val = Value::Composite(Composite::Unnamed(vec![
-			Value::Primitive(Primitive::Str("a".into())),
-			Value::Primitive(Primitive::Str("b".into())),
-			Value::Primitive(Primitive::Str("c".into())),
+		let val = ValueDef::Composite(Composite::Unnamed(vec![
+			Value::new(ValueDef::Primitive(Primitive::Str("a".into()))),
+			Value::new(ValueDef::Primitive(Primitive::Str("b".into()))),
+			Value::new(ValueDef::Primitive(Primitive::Str("c".into()))),
 		]));
 		assert_eq!(<Vec<String>>::deserialize(val), Ok(vec!["a".into(), "b".into(), "c".into()]));
 	}
@@ -1060,23 +1276,23 @@ mod test {
 	#[test]
 	fn de_unwrapped_into_vec() {
 		let val = Composite::Unnamed(vec![
-			Value::Primitive(Primitive::U8(1)),
-			Value::Primitive(Primitive::U8(2)),
-			Value::Primitive(Primitive::U8(3)),
+			Value::new(ValueDef::Primitive(Primitive::U8(1))),
+			Value::new(ValueDef::Primitive(Primitive::U8(2))),
+			Value::new(ValueDef::Primitive(Primitive::U8(3))),
 		]);
 		assert_eq!(<Vec<u8>>::deserialize(val), Ok(vec![1, 2, 3]));
 
 		let val = Composite::Named(vec![
-			("a".into(), Value::Primitive(Primitive::U8(1))),
-			("b".into(), Value::Primitive(Primitive::U8(2))),
-			("c".into(), Value::Primitive(Primitive::U8(3))),
+			("a".into(), Value::new(ValueDef::Primitive(Primitive::U8(1)))),
+			("b".into(), Value::new(ValueDef::Primitive(Primitive::U8(2)))),
+			("c".into(), Value::new(ValueDef::Primitive(Primitive::U8(3)))),
 		]);
 		assert_eq!(<Vec<u8>>::deserialize(val), Ok(vec![1, 2, 3]));
 
 		let val = Composite::Unnamed(vec![
-			Value::Primitive(Primitive::Str("a".into())),
-			Value::Primitive(Primitive::Str("b".into())),
-			Value::Primitive(Primitive::Str("c".into())),
+			Value::new(ValueDef::Primitive(Primitive::Str("a".into()))),
+			Value::new(ValueDef::Primitive(Primitive::Str("b".into()))),
+			Value::new(ValueDef::Primitive(Primitive::Str("c".into()))),
 		]);
 		assert_eq!(<Vec<String>>::deserialize(val), Ok(vec!["a".into(), "b".into(), "c".into()]));
 	}
@@ -1085,64 +1301,64 @@ mod test {
 	fn de_into_map() {
 		use std::collections::HashMap;
 
-		let val = Value::Composite(Composite::Named(vec![
-			("a".into(), Value::Primitive(Primitive::U8(1))),
-			("b".into(), Value::Primitive(Primitive::U8(2))),
-			("c".into(), Value::Primitive(Primitive::U8(3))),
+		let val = ValueDef::Composite(Composite::Named(vec![
+			("a".into(), Value::new(ValueDef::Primitive(Primitive::U8(1)))),
+			("b".into(), Value::new(ValueDef::Primitive(Primitive::U8(2)))),
+			("c".into(), Value::new(ValueDef::Primitive(Primitive::U8(3)))),
 		]));
 		assert_eq!(
 			<HashMap<String, u8>>::deserialize(val),
 			Ok(vec![("a".into(), 1), ("b".into(), 2), ("c".into(), 3)].into_iter().collect())
 		);
 
-		let val = Value::Composite(Composite::Unnamed(vec![
-			Value::Primitive(Primitive::U8(1)),
-			Value::Primitive(Primitive::U8(2)),
-			Value::Primitive(Primitive::U8(3)),
+		let val = ValueDef::Composite(Composite::Unnamed(vec![
+			Value::new(ValueDef::Primitive(Primitive::U8(1))),
+			Value::new(ValueDef::Primitive(Primitive::U8(2))),
+			Value::new(ValueDef::Primitive(Primitive::U8(3))),
 		]));
 		<HashMap<String, u8>>::deserialize(val).expect_err("no names; can't be map");
 	}
 
 	#[test]
 	fn de_into_tuple() {
-		let val = Value::Composite(Composite::Unnamed(vec![
-			Value::Primitive(Primitive::Str("hello".into())),
-			Value::Primitive(Primitive::Bool(true)),
+		let val = ValueDef::Composite(Composite::Unnamed(vec![
+			Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
+			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
 		]));
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
 		// names will just be ignored:
-		let val = Value::Composite(Composite::Named(vec![
-			("a".into(), Value::Primitive(Primitive::Str("hello".into()))),
-			("b".into(), Value::Primitive(Primitive::Bool(true))),
+		let val = ValueDef::Composite(Composite::Named(vec![
+			("a".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
+			("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
 		]));
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
 		// Enum variants are allowed! The variant name will be ignored:
-		let val = Value::Variant(Variant {
+		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::Primitive(Primitive::Str("hello".into())),
-				Value::Primitive(Primitive::Bool(true)),
+				Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
+				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
 			]),
 		});
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
 		// Enum variants with names values are allowed! The variant name will be ignored:
-		let val = Value::Variant(Variant {
+		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("a".into(), Value::Primitive(Primitive::Str("hello".into()))),
-				("b".into(), Value::Primitive(Primitive::Bool(true))),
+				("a".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
+				("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
 			]),
 		});
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
 		// Wrong number of values should fail:
-		let val = Value::Composite(Composite::Unnamed(vec![
-			Value::Primitive(Primitive::Str("hello".into())),
-			Value::Primitive(Primitive::Bool(true)),
-			Value::Primitive(Primitive::U8(123)),
+		let val = ValueDef::Composite(Composite::Unnamed(vec![
+			Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
+			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+			Value::new(ValueDef::Primitive(Primitive::U8(123))),
 		]));
 		<(String, bool)>::deserialize(val).expect_err("Wrong length, should err");
 	}
@@ -1150,23 +1366,23 @@ mod test {
 	#[test]
 	fn de_unwrapped_into_tuple() {
 		let val = Composite::Unnamed(vec![
-			Value::Primitive(Primitive::Str("hello".into())),
-			Value::Primitive(Primitive::Bool(true)),
+			Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
+			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
 		]);
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
 		// names will just be ignored:
 		let val = Composite::Named(vec![
-			("a".into(), Value::Primitive(Primitive::Str("hello".into()))),
-			("b".into(), Value::Primitive(Primitive::Bool(true))),
+			("a".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
+			("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
 		]);
 		assert_eq!(<(String, bool)>::deserialize(val), Ok(("hello".into(), true)));
 
 		// Wrong number of values should fail:
 		let val = Composite::Unnamed(vec![
-			Value::Primitive(Primitive::Str("hello".into())),
-			Value::Primitive(Primitive::Bool(true)),
-			Value::Primitive(Primitive::U8(123)),
+			Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
+			Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+			Value::new(ValueDef::Primitive(Primitive::U8(123))),
 		]);
 		<(String, bool)>::deserialize(val).expect_err("Wrong length, should err");
 	}
@@ -1175,10 +1391,10 @@ mod test {
 	fn de_bitvec() {
 		use bitvec::{bitvec, order::Lsb0};
 
-		let val = Value::BitSequence(bitvec![Lsb0, u8; 0, 1, 1, 0, 1, 0, 1, 0]);
+		let val = Value::new(ValueDef::BitSequence(bitvec![Lsb0, u8; 0, 1, 1, 0, 1, 0, 1, 0]));
 		assert_eq!(BitSequence::deserialize(val), Ok(bitvec![Lsb0, u8; 0, 1, 1, 0, 1, 0, 1, 0]));
 
-		let val = Value::BitSequence(bitvec![Lsb0, u8; 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0]);
+		let val = Value::new(ValueDef::BitSequence(bitvec![Lsb0, u8; 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0]));
 		assert_eq!(
 			BitSequence::deserialize(val),
 			Ok(bitvec![Lsb0, u8; 0, 1, 1, 0, 1, 0, 1, 0, 1, 1, 1, 1, 0, 0, 0, 1, 0])
@@ -1192,23 +1408,23 @@ mod test {
 			Foo(String, bool, u8),
 		}
 
-		let val = Value::Variant(Variant {
+		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::Primitive(Primitive::Str("hello".into())),
-				Value::Primitive(Primitive::Bool(true)),
-				Value::Primitive(Primitive::U8(123)),
+				Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
+				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+				Value::new(ValueDef::Primitive(Primitive::U8(123))),
 			]),
 		});
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo("hello".into(), true, 123)));
 
 		// it's fine to name the fields; we'll just ignore the names
-		let val = Value::Variant(Variant {
+		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("a".into(), Value::Primitive(Primitive::Str("hello".into()))),
-				("b".into(), Value::Primitive(Primitive::Bool(true))),
-				("c".into(), Value::Primitive(Primitive::U8(123))),
+				("a".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
+				("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
+				("c".into(), Value::new(ValueDef::Primitive(Primitive::U8(123)))),
 			]),
 		});
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo("hello".into(), true, 123)));
@@ -1224,9 +1440,9 @@ mod test {
 		let val = Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::Primitive(Primitive::Str("hello".into())),
-				Value::Primitive(Primitive::Bool(true)),
-				Value::Primitive(Primitive::U8(123)),
+				Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
+				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+				Value::new(ValueDef::Primitive(Primitive::U8(123))),
 			]),
 		};
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo("hello".into(), true, 123)));
@@ -1235,9 +1451,9 @@ mod test {
 		let val = Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("a".into(), Value::Primitive(Primitive::Str("hello".into()))),
-				("b".into(), Value::Primitive(Primitive::Bool(true))),
-				("c".into(), Value::Primitive(Primitive::U8(123))),
+				("a".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
+				("b".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
+				("c".into(), Value::new(ValueDef::Primitive(Primitive::U8(123)))),
 			]),
 		};
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo("hello".into(), true, 123)));
@@ -1251,60 +1467,60 @@ mod test {
 		}
 
 		// If names given, order doesn't matter:
-		let val = Value::Variant(Variant {
+		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
 				// Deliberately out of order: names should ensure alignment:
-				("b".into(), Value::Primitive(Primitive::U8(123))),
-				("a".into(), Value::Primitive(Primitive::Bool(true))),
-				("hi".into(), Value::Primitive(Primitive::Str("hello".into()))),
+				("b".into(), Value::new(ValueDef::Primitive(Primitive::U8(123)))),
+				("a".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
+				("hi".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
 			]),
 		});
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo { hi: "hello".into(), a: true, b: 123 }));
 
 		// No names needed if order is OK:
-		let val = Value::Variant(Variant {
+		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::Primitive(Primitive::Str("hello".into())),
-				Value::Primitive(Primitive::Bool(true)),
-				Value::Primitive(Primitive::U8(123)),
+				Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
+				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+				Value::new(ValueDef::Primitive(Primitive::U8(123))),
 			]),
 		});
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo { hi: "hello".into(), a: true, b: 123 }));
 
 		// Wrong order won't work if no names:
-		let val = Value::Variant(Variant {
+		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Unnamed(vec![
-				Value::Primitive(Primitive::Bool(true)),
-				Value::Primitive(Primitive::U8(123)),
-				Value::Primitive(Primitive::Str("hello".into())),
+				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
+				Value::new(ValueDef::Primitive(Primitive::U8(123))),
+				Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
 			]),
 		});
 		MyEnum::deserialize(val).expect_err("Wrong order shouldn't work");
 
 		// Wrong names won't work:
-		let val = Value::Variant(Variant {
+		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("b".into(), Value::Primitive(Primitive::U8(123))),
+				("b".into(), Value::new(ValueDef::Primitive(Primitive::U8(123)))),
 				// Whoops; wrong name:
-				("c".into(), Value::Primitive(Primitive::Bool(true))),
-				("hi".into(), Value::Primitive(Primitive::Str("hello".into()))),
+				("c".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
+				("hi".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
 			]),
 		});
 		MyEnum::deserialize(val).expect_err("Wrong names shouldn't work");
 
 		// Too many names is OK; we can ignore fields we don't care about:
-		let val = Value::Variant(Variant {
+		let val = ValueDef::Variant(Variant {
 			name: "Foo".into(),
 			values: Composite::Named(vec![
-				("foo".into(), Value::Primitive(Primitive::U8(40))),
-				("b".into(), Value::Primitive(Primitive::U8(123))),
-				("a".into(), Value::Primitive(Primitive::Bool(true))),
-				("bar".into(), Value::Primitive(Primitive::Bool(false))),
-				("hi".into(), Value::Primitive(Primitive::Str("hello".into()))),
+				("foo".into(), Value::new(ValueDef::Primitive(Primitive::U8(40)))),
+				("b".into(), Value::new(ValueDef::Primitive(Primitive::U8(123)))),
+				("a".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
+				("bar".into(), Value::new(ValueDef::Primitive(Primitive::Bool(false)))),
+				("hi".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
 			]),
 		});
 		assert_eq!(MyEnum::deserialize(val), Ok(MyEnum::Foo { hi: "hello".into(), a: true, b: 123 }));
@@ -1312,8 +1528,8 @@ mod test {
 
 	#[test]
 	fn de_into_unit_variants() {
-		let val = Value::Variant(Variant { name: "Foo".into(), values: Composite::Named(vec![]) });
-		let unwrapped_val = Variant { name: "Foo".into(), values: Composite::Named(vec![]) };
+		let val = Value::new(ValueDef::Variant(Variant { name: "Foo".into(), values: Composite::Named(vec![]) }));
+		let unwrapped_val = Variant::<()> { name: "Foo".into(), values: Composite::Named(vec![]) };
 
 		#[derive(Deserialize, Debug, PartialEq)]
 		enum MyEnum {

--- a/desub-current/src/value/mod.rs
+++ b/desub-current/src/value/mod.rs
@@ -44,9 +44,77 @@ pub struct Value<T> {
 }
 
 impl Value<()> {
-	/// Create a new value without any context.
-	pub fn new(value: ValueDef<()>) -> Value<()> {
-		Value { value, context: () }
+	/// Create a new named composite value without additional context.
+	pub fn named_composite(values: Vec<(String,Value<()>)>) -> Value<()> {
+		Value { value: ValueDef::Composite(Composite::Named(values)), context: () }
+	}
+	/// Create a new unnamed composite value without additional context.
+	pub fn unnamed_composite(values: Vec<Value<()>>) -> Value<()> {
+		Value { value: ValueDef::Composite(Composite::Unnamed(values)), context: () }
+	}
+	/// Create a new variant value without additional context.
+	pub fn variant(name: String, values: Composite<()>) -> Value<()> {
+		Value { value: ValueDef::Variant(Variant { name, values }), context: () }
+	}
+	/// Create a new bit sequence value without additional context.
+	pub fn bit_sequence(bitseq: BitSequence) -> Value<()> {
+		Value { value: ValueDef::BitSequence(bitseq), context: () }
+	}
+	/// Create a new primitive value without additional context.
+	pub fn primitive(primitive: Primitive) -> Value<()> {
+		Value { value: ValueDef::Primitive(primitive), context: () }
+	}
+	/// Create a new `bool` value without additional context.
+	pub fn bool(val: bool) -> Value<()> {
+		Value { value: ValueDef::Primitive(Primitive::Bool(val)), context: () }
+	}
+	/// Create a new `char` value without additional context.
+	pub fn char(val: char) -> Value<()> {
+		Value { value: ValueDef::Primitive(Primitive::Char(val)), context: () }
+	}
+	/// Create a new `str` value without additional context.
+	pub fn str(val: String) -> Value<()> {
+		Value { value: ValueDef::Primitive(Primitive::Str(val)), context: () }
+	}
+	/// Create a new `u8` value without additional context.
+	pub fn u8(val: u8) -> Value<()> {
+		Value { value: ValueDef::Primitive(Primitive::U8(val)), context: () }
+	}
+	/// Create a new `u16` value without additional context.
+	pub fn u16(val: u16) -> Value<()> {
+		Value { value: ValueDef::Primitive(Primitive::U16(val)), context: () }
+	}
+	/// Create a new `u32` value without additional context.
+	pub fn u32(val: u32) -> Value<()> {
+		Value { value: ValueDef::Primitive(Primitive::U32(val)), context: () }
+	}
+	/// Create a new `u64` value without additional context.
+	pub fn u64(val: u64) -> Value<()> {
+		Value { value: ValueDef::Primitive(Primitive::U64(val)), context: () }
+	}
+	/// Create a new `u128` value without additional context.
+	pub fn u128(val: u128) -> Value<()> {
+		Value { value: ValueDef::Primitive(Primitive::U128(val)), context: () }
+	}
+	/// Create a new `i8` value without additional context.
+	pub fn i8(val: i8) -> Value<()> {
+		Value { value: ValueDef::Primitive(Primitive::I8(val)), context: () }
+	}
+	/// Create a new `i16` value without additional context.
+	pub fn i16(val: i16) -> Value<()> {
+		Value { value: ValueDef::Primitive(Primitive::I16(val)), context: () }
+	}
+	/// Create a new `i32` value without additional context.
+	pub fn i32(val: i32) -> Value<()> {
+		Value { value: ValueDef::Primitive(Primitive::I32(val)), context: () }
+	}
+	/// Create a new `i64` value without additional context.
+	pub fn i64(val: i64) -> Value<()> {
+		Value { value: ValueDef::Primitive(Primitive::I64(val)), context: () }
+	}
+	/// Create a new `i128` value without additional context.
+	pub fn i128(val: i128) -> Value<()> {
+		Value { value: ValueDef::Primitive(Primitive::I128(val)), context: () }
 	}
 }
 

--- a/desub-current/src/value/mod.rs
+++ b/desub-current/src/value/mod.rs
@@ -128,12 +128,11 @@ impl<T> Value<T> {
 		self.map_context(|_| ())
 	}
 	/// Map the context to some different type.
-	pub fn map_context<F,U>(self, mut f: F) -> Value<U>
-	where F: Clone + FnMut(T) -> U {
-		Value {
-			context: f(self.context),
-			value: self.value.map_context(f)
-		}
+	pub fn map_context<F, U>(self, mut f: F) -> Value<U>
+	where
+		F: Clone + FnMut(T) -> U,
+	{
+		Value { context: f(self.context), value: self.value.map_context(f) }
 	}
 }
 
@@ -152,8 +151,10 @@ pub enum ValueDef<T> {
 
 impl<T> ValueDef<T> {
 	/// Map the context to some different type.
-	pub fn map_context<F,U>(self, f: F) -> ValueDef<U>
-	where F: Clone + FnMut(T) -> U {
+	pub fn map_context<F, U>(self, f: F) -> ValueDef<U>
+	where
+		F: Clone + FnMut(T) -> U,
+	{
 		match self {
 			ValueDef::Composite(val) => ValueDef::Composite(val.map_context(f)),
 			ValueDef::Variant(val) => ValueDef::Variant(val.map_context(f)),
@@ -203,8 +204,10 @@ impl<T> Composite<T> {
 	}
 
 	/// Map the context to some different type.
-	pub fn map_context<F,U>(self, f: F) -> Composite<U>
-	where F: Clone + FnMut(T) -> U {
+	pub fn map_context<F, U>(self, f: F) -> Composite<U>
+	where
+		F: Clone + FnMut(T) -> U,
+	{
 		match self {
 			Composite::Named(values) => {
 				// Note: Optimally I'd pass `&mut f` into each iteration to avoid cloning,
@@ -261,8 +264,10 @@ pub struct Variant<T> {
 
 impl<T> Variant<T> {
 	/// Map the context to some different type.
-	pub fn map_context<F,U>(self, f: F) -> Variant<U>
-	where F: Clone + FnMut(T) -> U {
+	pub fn map_context<F, U>(self, f: F) -> Variant<U>
+	where
+		F: Clone + FnMut(T) -> U,
+	{
 		Variant { name: self.name, values: self.values.map_context(f) }
 	}
 }

--- a/desub-current/src/value/mod.rs
+++ b/desub-current/src/value/mod.rs
@@ -185,6 +185,14 @@ impl <T> Composite<T> {
 		}
 	}
 
+	/// Is the composite type empty?
+	pub fn is_empty(&self) -> bool {
+		match self {
+			Composite::Named(values) => values.is_empty(),
+			Composite::Unnamed(values) => values.is_empty(),
+		}
+	}
+
 	/// Remove the context.
 	pub fn without_context(self) -> Composite<()> {
 		match self {

--- a/desub-current/src/value/mod.rs
+++ b/desub-current/src/value/mod.rs
@@ -40,12 +40,12 @@ pub struct Value<T> {
 	/// The shape and associated values for this Value
 	pub value: ValueDef<T>,
 	/// Some additional arbitrary context that can be associated with a value.
-	pub context: T
+	pub context: T,
 }
 
 impl Value<()> {
 	/// Create a new named composite value without additional context.
-	pub fn named_composite(values: Vec<(String,Value<()>)>) -> Value<()> {
+	pub fn named_composite(values: Vec<(String, Value<()>)>) -> Value<()> {
 		Value { value: ValueDef::Composite(Composite::Named(values)), context: () }
 	}
 	/// Create a new unnamed composite value without additional context.
@@ -118,7 +118,7 @@ impl Value<()> {
 	}
 }
 
-impl <T> Value<T> {
+impl<T> Value<T> {
 	/// Create a new value with some associated context.
 	pub fn with_context(value: ValueDef<T>, context: T) -> Value<T> {
 		Value { value, context }
@@ -142,7 +142,7 @@ pub enum ValueDef<T> {
 	Primitive(Primitive),
 }
 
-impl <T> ValueDef<T> {
+impl<T> ValueDef<T> {
 	/// Remove the context.
 	pub fn without_context(self) -> ValueDef<()> {
 		match self {
@@ -154,7 +154,7 @@ impl <T> ValueDef<T> {
 	}
 }
 
-impl <T: Debug> Debug for ValueDef<T> {
+impl<T: Debug> Debug for ValueDef<T> {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
 			Self::Composite(val) => Debug::fmt(val, f),
@@ -176,7 +176,7 @@ pub enum Composite<T> {
 	Unnamed(Vec<Value<T>>),
 }
 
-impl <T> Composite<T> {
+impl<T> Composite<T> {
 	/// Return the number of values stored in this composite type.
 	pub fn len(&self) -> usize {
 		match self {
@@ -197,24 +197,18 @@ impl <T> Composite<T> {
 	pub fn without_context(self) -> Composite<()> {
 		match self {
 			Composite::Named(values) => {
-				let vals = values
-					.into_iter()
-					.map(|(k,v)| (k, v.without_context()))
-					.collect();
+				let vals = values.into_iter().map(|(k, v)| (k, v.without_context())).collect();
 				Composite::Named(vals)
-			},
+			}
 			Composite::Unnamed(values) => {
-				let vals = values
-					.into_iter()
-					.map(|v| v.without_context())
-					.collect();
+				let vals = values.into_iter().map(|v| v.without_context()).collect();
 				Composite::Unnamed(vals)
-			},
+			}
 		}
 	}
 }
 
-impl <T: Debug> Debug for Composite<T> {
+impl<T: Debug> Debug for Composite<T> {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		match self {
 			Composite::Named(fields) => {
@@ -235,7 +229,7 @@ impl <T: Debug> Debug for Composite<T> {
 	}
 }
 
-impl <T> From<Composite<T>> for ValueDef<T> {
+impl<T> From<Composite<T>> for ValueDef<T> {
 	fn from(val: Composite<T>) -> Self {
 		ValueDef::Composite(val)
 	}
@@ -251,17 +245,14 @@ pub struct Variant<T> {
 	pub values: Composite<T>,
 }
 
-impl <T> Variant<T> {
+impl<T> Variant<T> {
 	/// Remove the context.
 	pub fn without_context(self) -> Variant<()> {
-		Variant {
-			name: self.name,
-			values: self.values.without_context()
-		}
+		Variant { name: self.name, values: self.values.without_context() }
 	}
 }
 
-impl <T: Debug> Debug for Variant<T> {
+impl<T: Debug> Debug for Variant<T> {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		f.write_str(&self.name)?;
 		f.write_str(" ")?;
@@ -269,7 +260,7 @@ impl <T: Debug> Debug for Variant<T> {
 	}
 }
 
-impl <T> From<Variant<T>> for ValueDef<T> {
+impl<T> From<Variant<T>> for ValueDef<T> {
 	fn from(val: Variant<T>) -> Self {
 		ValueDef::Variant(val)
 	}
@@ -295,7 +286,7 @@ pub enum Primitive {
 	I256([u8; 32]),
 }
 
-impl <T> From<Primitive> for ValueDef<T> {
+impl<T> From<Primitive> for ValueDef<T> {
 	fn from(val: Primitive) -> Self {
 		ValueDef::Primitive(val)
 	}

--- a/desub-current/src/value/mod.rs
+++ b/desub-current/src/value/mod.rs
@@ -43,6 +43,15 @@ pub struct Value<T> {
 	pub context: T,
 }
 
+macro_rules! value_prim_method {
+	($name:ident $variant:ident) => {
+		#[doc = concat!("Create a new `", stringify!($name), "` value without additional context")]
+		pub fn $name(val: $name) -> Value<()> {
+			Value { value: ValueDef::Primitive(Primitive::$variant(val)), context: () }
+		}
+	}
+}
+
 impl Value<()> {
 	/// Create a new named composite value without additional context.
 	pub fn named_composite(values: Vec<(String, Value<()>)>) -> Value<()> {
@@ -64,58 +73,23 @@ impl Value<()> {
 	pub fn primitive(primitive: Primitive) -> Value<()> {
 		Value { value: ValueDef::Primitive(primitive), context: () }
 	}
-	/// Create a new `bool` value without additional context.
-	pub fn bool(val: bool) -> Value<()> {
-		Value { value: ValueDef::Primitive(Primitive::Bool(val)), context: () }
-	}
-	/// Create a new `char` value without additional context.
-	pub fn char(val: char) -> Value<()> {
-		Value { value: ValueDef::Primitive(Primitive::Char(val)), context: () }
-	}
-	/// Create a new `str` value without additional context.
+	/// Create a new string value without additional context.
 	pub fn str(val: String) -> Value<()> {
 		Value { value: ValueDef::Primitive(Primitive::Str(val)), context: () }
 	}
-	/// Create a new `u8` value without additional context.
-	pub fn u8(val: u8) -> Value<()> {
-		Value { value: ValueDef::Primitive(Primitive::U8(val)), context: () }
-	}
-	/// Create a new `u16` value without additional context.
-	pub fn u16(val: u16) -> Value<()> {
-		Value { value: ValueDef::Primitive(Primitive::U16(val)), context: () }
-	}
-	/// Create a new `u32` value without additional context.
-	pub fn u32(val: u32) -> Value<()> {
-		Value { value: ValueDef::Primitive(Primitive::U32(val)), context: () }
-	}
-	/// Create a new `u64` value without additional context.
-	pub fn u64(val: u64) -> Value<()> {
-		Value { value: ValueDef::Primitive(Primitive::U64(val)), context: () }
-	}
-	/// Create a new `u128` value without additional context.
-	pub fn u128(val: u128) -> Value<()> {
-		Value { value: ValueDef::Primitive(Primitive::U128(val)), context: () }
-	}
-	/// Create a new `i8` value without additional context.
-	pub fn i8(val: i8) -> Value<()> {
-		Value { value: ValueDef::Primitive(Primitive::I8(val)), context: () }
-	}
-	/// Create a new `i16` value without additional context.
-	pub fn i16(val: i16) -> Value<()> {
-		Value { value: ValueDef::Primitive(Primitive::I16(val)), context: () }
-	}
-	/// Create a new `i32` value without additional context.
-	pub fn i32(val: i32) -> Value<()> {
-		Value { value: ValueDef::Primitive(Primitive::I32(val)), context: () }
-	}
-	/// Create a new `i64` value without additional context.
-	pub fn i64(val: i64) -> Value<()> {
-		Value { value: ValueDef::Primitive(Primitive::I64(val)), context: () }
-	}
-	/// Create a new `i128` value without additional context.
-	pub fn i128(val: i128) -> Value<()> {
-		Value { value: ValueDef::Primitive(Primitive::I128(val)), context: () }
-	}
+
+	value_prim_method!(bool Bool);
+	value_prim_method!(char Char);
+	value_prim_method!(u8 U8);
+	value_prim_method!(u16 U16);
+	value_prim_method!(u32 U32);
+	value_prim_method!(u64 U64);
+	value_prim_method!(u128 U128);
+	value_prim_method!(i8 I8);
+	value_prim_method!(i16 I16);
+	value_prim_method!(i32 I32);
+	value_prim_method!(i64 I64);
+	value_prim_method!(i128 I128);
 }
 
 impl<T> Value<T> {

--- a/desub-current/src/value/serialize.rs
+++ b/desub-current/src/value/serialize.rs
@@ -116,7 +116,7 @@ mod test {
 	use super::*;
 	use serde_json::json;
 
-	fn assert_value(value: ValueDef<()>, expected: serde_json::Value) {
+	fn assert_value(value: Value<()>, expected: serde_json::Value) {
 		let val = serde_json::to_value(&value).expect("can serialize to serde_json::Value");
 		assert_eq!(val, expected);
 	}
@@ -124,22 +124,22 @@ mod test {
 	#[test]
 	fn serialize_primitives() {
 		// a subset of the primitives to sanity check that they are unwrapped:
-		assert_value(ValueDef::Primitive(Primitive::U8(1)), json!(1));
-		assert_value(ValueDef::Primitive(Primitive::U16(1)), json!(1));
-		assert_value(ValueDef::Primitive(Primitive::U32(1)), json!(1));
-		assert_value(ValueDef::Primitive(Primitive::U64(1)), json!(1));
-		assert_value(ValueDef::Primitive(Primitive::Bool(true)), json!(true));
-		assert_value(ValueDef::Primitive(Primitive::Bool(false)), json!(false));
+		assert_value(Value::u8(1), json!(1));
+		assert_value(Value::u16(1), json!(1));
+		assert_value(Value::u32(1), json!(1));
+		assert_value(Value::u64(1), json!(1));
+		assert_value(Value::bool(true), json!(true));
+		assert_value(Value::bool(false), json!(false));
 	}
 
 	#[test]
 	fn serialize_composites() {
 		assert_value(
-			ValueDef::Composite(Composite::Named(vec![
-				("a".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
-				("b".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
-				("c".into(), Value::new(ValueDef::Primitive(Primitive::Char('c')))),
-			])),
+			Value::named_composite(vec![
+				("a".into(), Value::bool(true)),
+				("b".into(), Value::str("hello".into())),
+				("c".into(), Value::char('c')),
+			]),
 			json!({
 				"a": true,
 				"b": "hello",
@@ -147,11 +147,11 @@ mod test {
 			}),
 		);
 		assert_value(
-			ValueDef::Composite(Composite::Unnamed(vec![
-				Value::new(ValueDef::Primitive(Primitive::Bool(true))),
-				Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
-				Value::new(ValueDef::Primitive(Primitive::Char('c'))),
-			])),
+			Value::unnamed_composite(vec![
+				Value::bool(true),
+				Value::str("hello".into()),
+				Value::char('c'),
+			]),
 			json!([true, "hello", 'c']),
 		)
 	}
@@ -159,14 +159,14 @@ mod test {
 	#[test]
 	fn serialize_variants() {
 		assert_value(
-			ValueDef::Variant(Variant {
-				name: "Foo".into(),
-				values: Composite::Named(vec![
-					("a".into(), Value::new(ValueDef::Primitive(Primitive::Bool(true)))),
-					("b".into(), Value::new(ValueDef::Primitive(Primitive::Str("hello".into())))),
-					("c".into(), Value::new(ValueDef::Primitive(Primitive::Char('c')))),
+			Value::variant(
+				"Foo".into(),
+				Composite::Named(vec![
+					("a".into(), Value::bool(true)),
+					("b".into(), Value::str("hello".into())),
+					("c".into(), Value::char('c')),
 				]),
-			}),
+			),
 			json!({
 				"name": "Foo",
 				"values": {
@@ -177,14 +177,14 @@ mod test {
 			}),
 		);
 		assert_value(
-			ValueDef::Variant(Variant {
-				name: "Bar".into(),
-				values: Composite::Unnamed(vec![
-					Value::new(ValueDef::Primitive(Primitive::Bool(true))),
-					Value::new(ValueDef::Primitive(Primitive::Str("hello".into()))),
-					Value::new(ValueDef::Primitive(Primitive::Char('c'))),
+			Value::variant(
+				"Bar".into(),
+				Composite::Unnamed(vec![
+					Value::bool(true),
+					Value::str("hello".into()),
+					Value::char('c'),
 				]),
-			}),
+			),
 			json!({
 				"name": "Bar",
 				"values": [

--- a/desub-current/src/value/serialize.rs
+++ b/desub-current/src/value/serialize.rs
@@ -20,7 +20,7 @@ use serde::{
 	Serialize,
 };
 
-impl <T> Serialize for Value<T> {
+impl<T> Serialize for Value<T> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: serde::Serializer,
@@ -29,7 +29,7 @@ impl <T> Serialize for Value<T> {
 	}
 }
 
-impl <T> Serialize for ValueDef<T> {
+impl<T> Serialize for ValueDef<T> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: serde::Serializer,
@@ -43,7 +43,7 @@ impl <T> Serialize for ValueDef<T> {
 	}
 }
 
-impl <T> Serialize for Composite<T> {
+impl<T> Serialize for Composite<T> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: serde::Serializer,
@@ -93,7 +93,7 @@ impl Serialize for Primitive {
 	}
 }
 
-impl <T> Serialize for Variant<T> {
+impl<T> Serialize for Variant<T> {
 	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
 	where
 		S: serde::Serializer,
@@ -147,11 +147,7 @@ mod test {
 			}),
 		);
 		assert_value(
-			Value::unnamed_composite(vec![
-				Value::bool(true),
-				Value::str("hello".into()),
-				Value::char('c'),
-			]),
+			Value::unnamed_composite(vec![Value::bool(true), Value::str("hello".into()), Value::char('c')]),
 			json!([true, "hello", 'c']),
 		)
 	}
@@ -179,11 +175,7 @@ mod test {
 		assert_value(
 			Value::variant(
 				"Bar".into(),
-				Composite::Unnamed(vec![
-					Value::bool(true),
-					Value::str("hello".into()),
-					Value::char('c'),
-				]),
+				Composite::Unnamed(vec![Value::bool(true), Value::str("hello".into()), Value::char('c')]),
 			),
 			json!({
 				"name": "Bar",

--- a/desub-current/tests/decode_extrinsics.rs
+++ b/desub-current/tests/decode_extrinsics.rs
@@ -291,60 +291,63 @@ fn can_decode_signer_payload() {
 	assert_eq!(&*r.call_data.ty.name(), "chill");
 	assert_eq!(r.call_data.arguments, vec![]);
 
-	assert_eq!(
-		r.without_context().extensions,
-		vec![
-			(
-				"CheckSpecVersion".into(),
-				SignedExtensionWithAdditional { extension: empty_value(), additional: prim_u32_value(9110) }
-			),
-			(
-				"CheckTxVersion".into(),
-				SignedExtensionWithAdditional { extension: empty_value(), additional: prim_u32_value(8) }
-			),
-			(
-				"CheckGenesis".into(),
-				SignedExtensionWithAdditional {
-					extension: empty_value(),
-					additional: hash_value(to_bytes(
-						"0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3"
-					))
-				}
-			),
-			(
-				"CheckMortality".into(),
-				SignedExtensionWithAdditional {
-					extension: singleton_value(variant_value(
-						"Mortal185",
-						value::Composite::Unnamed(vec![prim_u8_value(52)])
-					)),
-					additional: hash_value(to_bytes(
-						"0x1c81d421f68281950ad2901291603b5e49fc5c872f129e75433f4b55f07ca072"
-					))
-				}
-			),
-			(
-				"CheckNonce".into(),
-				SignedExtensionWithAdditional {
-					extension: singleton_value(prim_u32_value(0)),
-					additional: empty_value()
-				}
-			),
-			(
-				"CheckWeight".into(),
-				SignedExtensionWithAdditional { extension: empty_value(), additional: empty_value() }
-			),
-			(
-				"ChargeTransactionPayment".into(),
-				SignedExtensionWithAdditional {
-					extension: singleton_value(prim_u128_value(0)),
-					additional: empty_value()
-				}
-			),
-			(
-				"PrevalidateAttests".into(),
-				SignedExtensionWithAdditional { extension: empty_value(), additional: empty_value() }
-			),
-		],
-	);
+	// Expected tuples of name, extension, additional.
+	let expected = vec![
+		(
+			"CheckSpecVersion",
+			empty_value(),
+			prim_u32_value(9110)
+		),
+		(
+			"CheckTxVersion",
+			empty_value(),
+			prim_u32_value(8)
+		),
+		(
+			"CheckGenesis",
+			empty_value(),
+			hash_value(to_bytes(
+				"0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3"
+			))
+		),
+		(
+			"CheckMortality",
+			singleton_value(variant_value(
+				"Mortal185",
+				value::Composite::Unnamed(vec![prim_u8_value(52)])
+			)),
+			hash_value(to_bytes(
+				"0x1c81d421f68281950ad2901291603b5e49fc5c872f129e75433f4b55f07ca072"
+			))
+		),
+		(
+			"CheckNonce",
+			singleton_value(prim_u32_value(0)),
+			empty_value()
+		),
+		(
+			"CheckWeight",
+			empty_value(),
+			empty_value()
+		),
+		(
+			"ChargeTransactionPayment",
+			singleton_value(prim_u128_value(0)),
+			empty_value()
+		),
+		(
+			"PrevalidateAttests",
+			empty_value(),
+			empty_value()
+		),
+	];
+
+	for (actual, expected) in r.extensions.into_iter().zip(expected) {
+		let (name, SignedExtensionWithAdditional { extension, additional }) = actual;
+		let (expected_name, expected_extension, expected_additional) = expected;
+
+		assert_eq!(&*name, expected_name);
+		assert_eq!(extension.without_context(), expected_extension);
+		assert_eq!(additional.without_context(), expected_additional);
+	}
 }

--- a/desub-current/tests/decode_extrinsics.rs
+++ b/desub-current/tests/decode_extrinsics.rs
@@ -16,7 +16,7 @@
 
 use desub_current::{
 	decoder::{self, SignedExtensionWithAdditional},
-	value, Metadata, Value, ValueDef
+	value, Metadata, Value, ValueDef,
 };
 
 static V14_METADATA_POLKADOT_SCALE: &[u8] = include_bytes!("data/v14_metadata_polkadot.scale");
@@ -123,13 +123,7 @@ fn auctions_bid_unsigned() {
 
 	assert_args_equal(
 		&ext.call_data.arguments,
-		vec![
-			singleton_value(Value::u32(1)),
-			Value::u32(2),
-			Value::u32(3),
-			Value::u32(4),
-			Value::u128(5),
-		]
+		vec![singleton_value(Value::u32(1)), Value::u32(2), Value::u32(3), Value::u32(4), Value::u128(5)],
 	);
 }
 
@@ -269,53 +263,22 @@ fn can_decode_signer_payload() {
 
 	// Expected tuples of name, extension, additional.
 	let expected = vec![
-		(
-			"CheckSpecVersion",
-			empty_value(),
-			Value::u32(9110)
-		),
-		(
-			"CheckTxVersion",
-			empty_value(),
-			Value::u32(8)
-		),
+		("CheckSpecVersion", empty_value(), Value::u32(9110)),
+		("CheckTxVersion", empty_value(), Value::u32(8)),
 		(
 			"CheckGenesis",
 			empty_value(),
-			hash_value(to_bytes(
-				"0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3"
-			))
+			hash_value(to_bytes("0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3")),
 		),
 		(
 			"CheckMortality",
-			singleton_value(Value::variant(
-				"Mortal185".to_string(),
-				value::Composite::Unnamed(vec![Value::u8(52)])
-			)),
-			hash_value(to_bytes(
-				"0x1c81d421f68281950ad2901291603b5e49fc5c872f129e75433f4b55f07ca072"
-			))
+			singleton_value(Value::variant("Mortal185".to_string(), value::Composite::Unnamed(vec![Value::u8(52)]))),
+			hash_value(to_bytes("0x1c81d421f68281950ad2901291603b5e49fc5c872f129e75433f4b55f07ca072")),
 		),
-		(
-			"CheckNonce",
-			singleton_value(Value::u32(0)),
-			empty_value()
-		),
-		(
-			"CheckWeight",
-			empty_value(),
-			empty_value()
-		),
-		(
-			"ChargeTransactionPayment",
-			singleton_value(Value::u128(0)),
-			empty_value()
-		),
-		(
-			"PrevalidateAttests",
-			empty_value(),
-			empty_value()
-		),
+		("CheckNonce", singleton_value(Value::u32(0)), empty_value()),
+		("CheckWeight", empty_value(), empty_value()),
+		("ChargeTransactionPayment", singleton_value(Value::u128(0)), empty_value()),
+		("PrevalidateAttests", empty_value(), empty_value()),
 	];
 
 	for (actual, expected) in r.extensions.into_iter().zip(expected) {

--- a/desub-current/tests/decode_storage.rs
+++ b/desub-current/tests/decode_storage.rs
@@ -17,7 +17,7 @@
 use codec::Encode;
 use desub_current::{
 	decoder::{self, StorageHasher},
-	Metadata, Value
+	Metadata, Value,
 };
 use sp_runtime::AccountId32;
 
@@ -29,11 +29,7 @@ fn metadata() -> Metadata {
 
 fn account_id_to_value(account_id: &AccountId32) -> Value<()> {
 	let account_id_bytes: &[u8] = account_id.as_ref();
-	Value::unnamed_composite(vec![
-		Value::unnamed_composite(
-			account_id_bytes.iter().map(|&b| Value::u8(b)).collect(),
-		)
-	])
+	Value::unnamed_composite(vec![Value::unnamed_composite(account_id_bytes.iter().map(|&b| Value::u8(b)).collect())])
 }
 
 macro_rules! assert_hasher_eq {
@@ -43,7 +39,7 @@ macro_rules! assert_hasher_eq {
 		} else {
 			panic!("Passed {:?}, but expected hasher {}", $actual, stringify!($hasher));
 		}
-	}
+	};
 }
 
 macro_rules! bytes {
@@ -92,12 +88,10 @@ fn democracy_blacklist() {
 
 	// Because the hasher is Identity, we can even see the decoded original map key:
 	assert_eq!(keys.len(), 1);
-	assert_hasher_eq!(keys[0].hasher, StorageHasher::Identity,
-		Value::unnamed_composite(vec![
-			Value::unnamed_composite(
-				vec![Value::u8(1); 32]
-			)
-		])
+	assert_hasher_eq!(
+		keys[0].hasher,
+		StorageHasher::Identity,
+		Value::unnamed_composite(vec![Value::unnamed_composite(vec![Value::u8(1); 32])])
 	);
 	assert!(matches!(keys[0].hasher, StorageHasher::Identity(..)));
 }
@@ -128,7 +122,7 @@ fn system_blockhash() {
 	assert_eq!(
 		val.without_context(),
 		// The Type appears to take the form of a newtype-wrapped [u8; 32]:
-		Value::unnamed_composite(vec![Value::unnamed_composite(vec![ Value::u8(1); 32 ])])
+		Value::unnamed_composite(vec![Value::unnamed_composite(vec![Value::u8(1); 32])])
 	);
 }
 

--- a/desub-current/tests/decode_storage.rs
+++ b/desub-current/tests/decode_storage.rs
@@ -18,7 +18,7 @@ use codec::Encode;
 use desub_current::{
 	decoder::{self, StorageHasher},
 	value::{Composite, Primitive},
-	Metadata, Value,
+	Metadata, Value, ValueDef
 };
 use sp_runtime::AccountId32;
 
@@ -28,11 +28,23 @@ fn metadata() -> Metadata {
 	Metadata::from_bytes(V14_METADATA_POLKADOT_SCALE).expect("valid metadata")
 }
 
-fn account_id_to_value(account_id: &AccountId32) -> Value {
+fn account_id_to_value(account_id: &AccountId32) -> Value<()> {
 	let account_id_bytes: &[u8] = account_id.as_ref();
-	Value::Composite(Composite::Unnamed(vec![Value::Composite(Composite::Unnamed(
-		account_id_bytes.iter().map(|&b| Value::Primitive(Primitive::U8(b))).collect(),
-	))]))
+	Value::new(ValueDef::Composite(Composite::Unnamed(vec![
+		Value::new(ValueDef::Composite(Composite::Unnamed(
+			account_id_bytes.iter().map(|&b| Value::new(ValueDef::Primitive(Primitive::U8(b)))).collect(),
+		)))
+	])))
+}
+
+macro_rules! assert_hasher_eq {
+	($actual:expr, $hasher:path, $value:expr) => {
+		if let $hasher(val) = &$actual {
+			assert_eq!(val.clone().without_context(), $value);
+		} else {
+			panic!("Passed {:?}, but expected hasher {}", $actual, stringify!($hasher));
+		}
+	}
 }
 
 macro_rules! bytes {
@@ -60,7 +72,7 @@ fn timestamp_now() {
 	// We can decode values at this location, now:
 	let bytes = 123u64.encode();
 	let val = decoder::decode_value_by_id(&meta, &entry.ty, &mut &*bytes).unwrap();
-	assert_eq!(val, Value::Primitive(Primitive::U64(123)));
+	assert_eq!(val.without_context(), Value::new(ValueDef::Primitive(Primitive::U64(123))));
 }
 
 // A simple map lookup with an Identity hash (ie just the key itself)
@@ -81,12 +93,14 @@ fn democracy_blacklist() {
 
 	// Because the hasher is Identity, we can even see the decoded original map key:
 	assert_eq!(keys.len(), 1);
-	assert_eq!(
-		keys[0].hasher,
-		StorageHasher::Identity(Value::Composite(Composite::Unnamed(vec![Value::Composite(Composite::Unnamed(
-			vec![Value::Primitive(Primitive::U8(1)); 32]
-		))])))
+	assert_hasher_eq!(keys[0].hasher, StorageHasher::Identity,
+		Value::new(ValueDef::Composite(Composite::Unnamed(vec![
+			Value::new(ValueDef::Composite(Composite::Unnamed(
+				vec![Value::new(ValueDef::Primitive(Primitive::U8(1))); 32]
+			)))
+		])))
 	);
+	assert!(matches!(keys[0].hasher, StorageHasher::Identity(..)));
 }
 
 // A map storage entry with a Twox64Concat key.
@@ -107,20 +121,20 @@ fn system_blockhash() {
 
 	// Because the hasher is Twox64Concat, we can even see the decoded original map key:
 	assert_eq!(keys.len(), 1);
-	assert_eq!(keys[0].hasher, StorageHasher::Twox64Concat(Value::Primitive(Primitive::U32(1000))));
+	assert_hasher_eq!(keys[0].hasher, StorageHasher::Twox64Concat, Value::new(ValueDef::Primitive(Primitive::U32(1000))));
 
 	// We can decode values at this location:
 	let bytes = [1u8; 32].encode();
 	let val = decoder::decode_value_by_id(&meta, &entry.ty, &mut &*bytes).unwrap();
 	assert_eq!(
-		val,
+		val.without_context(),
 		// The Type appears to take the form of a newtype-wrapped [u8; 32]:
-		Value::Composite(Composite::Unnamed(vec![Value::Composite(Composite::Unnamed(vec![
-			Value::Primitive(
+		Value::new(ValueDef::Composite(Composite::Unnamed(vec![Value::new(ValueDef::Composite(Composite::Unnamed(vec![
+			Value::new(ValueDef::Primitive(
 				Primitive::U8(1)
-			);
+			));
 			32
-		]))]))
+		])))])))
 	);
 }
 
@@ -144,7 +158,7 @@ fn balances_account() {
 	let bobs_value = account_id_to_value(&bobs_accountid);
 
 	assert_eq!(keys.len(), 1);
-	assert_eq!(keys[0].hasher, StorageHasher::Blake2_128Concat(bobs_value));
+	assert_hasher_eq!(keys[0].hasher, StorageHasher::Blake2_128Concat, bobs_value);
 }
 
 // A map storage entry keyed by a tuple of 2 Twox64Concat values.
@@ -168,11 +182,11 @@ fn imonline_authoredblocks() {
 
 	// Because the hashers are Twox64Concat, we can check the keys we provided:
 	assert_eq!(keys.len(), 2);
-	assert_eq!(keys[0].hasher, StorageHasher::Twox64Concat(Value::Primitive(Primitive::U32(1234))));
-	assert_eq!(keys[1].hasher, StorageHasher::Twox64Concat(bobs_value));
+	assert_hasher_eq!(keys[0].hasher, StorageHasher::Twox64Concat, Value::new(ValueDef::Primitive(Primitive::U32(1234))));
+	assert_hasher_eq!(keys[1].hasher, StorageHasher::Twox64Concat, bobs_value);
 
 	// We can decode values at this location:
 	let bytes = 5678u32.encode();
 	let val = decoder::decode_value_by_id(&meta, &entry.ty, &mut &*bytes).unwrap();
-	assert_eq!(val, Value::Primitive(Primitive::U32(5678)));
+	assert_eq!(val.without_context(), Value::new(ValueDef::Primitive(Primitive::U32(5678))));
 }

--- a/desub/src/error.rs
+++ b/desub/src/error.rs
@@ -17,7 +17,6 @@
 use desub_current::{
 	decoder::{DecodeError, Extrinsic},
 	metadata::MetadataError,
-	TypeId
 };
 use desub_legacy::{decoder::metadata::Error as LegacyMetadataError, Error as LegacyError};
 use thiserror::Error;
@@ -28,7 +27,7 @@ pub enum Error {
 	V14 {
 		#[source]
 		source: DecodeError,
-		ext: Vec<Extrinsic<'static, TypeId>>,
+		ext: Vec<Extrinsic<'static>>,
 	},
 	#[error(transparent)]
 	Legacy(#[from] LegacyError),

--- a/desub/src/error.rs
+++ b/desub/src/error.rs
@@ -17,6 +17,7 @@
 use desub_current::{
 	decoder::{DecodeError, Extrinsic},
 	metadata::MetadataError,
+	TypeId
 };
 use desub_legacy::{decoder::metadata::Error as LegacyMetadataError, Error as LegacyError};
 use thiserror::Error;
@@ -27,7 +28,7 @@ pub enum Error {
 	V14 {
 		#[source]
 		source: DecodeError,
-		ext: Vec<Extrinsic<'static>>,
+		ext: Vec<Extrinsic<'static, TypeId>>,
 	},
 	#[error(transparent)]
 	Legacy(#[from] LegacyError),


### PR DESCRIPTION
This PR turns the `Value` type into a `Value<T>` type, such that each value holds an instance of some type T in order that we can add contextual information to values.

Our decoding functions now return `Value<TypeId>`, so that given a value (or a value inside a value..), we can look up the corresponding type information in the metadata.

It's possible to serialize a `Value<T>` just as it was a `Value` (we ignore the contextual `T` when serializing). We can only deserialize data into a `Value<()>` though (since we cannot deserialize contextual information, it's best I think to make it clear that no additional information can be held when deserializing).

Finally, add helper functions on `Value` to make it much easier to create instances of values, because with the added layer here, that was becoming pretty cumbersome!

Closes #60 