### PR TITLE
Normalize imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "desub-legacy"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "bitvec",
  "derive_more",

--- a/desub-common/Cargo.toml
+++ b/desub-common/Cargo.toml
@@ -12,8 +12,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sp-runtime = { package = "sp-runtime",  git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
-sp-core = { package = "sp-core",  git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
 serde = { version = "1", features = [ "derive" ] }
 
-
+sp-runtime = {git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
+sp-core = {git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }

--- a/desub-current/Cargo.toml
+++ b/desub-current/Cargo.toml
@@ -14,8 +14,6 @@ edition = "2021"
 [dependencies]
 log = "0.4"
 thiserror = "1.0.30"
-sp_core = { package = "sp-core",  git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
-sp_runtime = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
 frame-metadata = { version = "14.2", features = ["v14", "std", "scale-info"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
@@ -25,6 +23,9 @@ derive_more = "0.99.16"
 scale-info = { version = "1.0.0", features = ["bit-vec", "derive"] }
 bitvec = { version = "0.20.2", features = ["serde", "alloc"] }
 desub-common = { path = "../desub-common" }
+
+sp-core = { git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
+sp-runtime = {git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
 
 [dev-dependencies]
 serde_json = "1"

--- a/desub-legacy/Cargo.toml
+++ b/desub-legacy/Cargo.toml
@@ -20,16 +20,15 @@ derive_more = "0.99.3"
 dyn-clone = "1.0"
 hex = "0.4"
 bitvec = { version = "0.20.2", features = ["serde", "alloc"] }
+frame-metadata = { version = "14.2", features = ["legacy"] }
 
 desub-common = { path = "../desub-common/" }
 
-pallet-democracy = { package = "pallet-democracy", git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
-primitives = { package = "sp-core",  git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
-runtime-primitives = { package = "sp-runtime", git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
-frame-metadata = { version = "14.2", features = ["legacy"] }
+sp-core = { git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
+sp-runtime = { git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
+pallet-democracy = { git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
 
 [dev-dependencies]
 runtime-version = { package = "sp-version", git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
 pretty_env_logger = "0.4"
 hex = "0.4"
-

--- a/desub-legacy/src/decoder.rs
+++ b/desub-legacy/src/decoder.rs
@@ -895,16 +895,16 @@ impl Decoder {
 			}
 			"Era" => {
 				log::trace!("ERA DATA: {:X?}", &state.data[state.cursor()]);
-				let val: runtime_primitives::generic::Era = state.decode()?;
+				let val: sp_runtime::generic::Era = state.decode()?;
 				log::trace!("Resolved Era: {:?}", val);
 				Ok(Some(SubstrateType::Era(val)))
 			}
 			"H256" => {
-				let val: primitives::H256 = state.decode()?;
+				let val: sp_core::H256 = state.decode()?;
 				Ok(Some(SubstrateType::H256(val)))
 			}
 			"H512" => {
-				let val: primitives::H512 = state.decode()?;
+				let val: sp_core::H512 = state.decode()?;
 				log::trace!("H512: {}", hex::encode(val.as_bytes()));
 				Ok(Some(SubstrateType::H512(val)))
 			}

--- a/desub-legacy/src/decoder/metadata.rs
+++ b/desub-legacy/src/decoder/metadata.rs
@@ -40,7 +40,7 @@ pub use frame_metadata::{decode_different::DecodeDifferent, RuntimeMetadata, Run
 use super::storage::{StorageInfo, StorageLookupTable};
 use crate::RustTypeMarker;
 use codec::{Decode, Encode, EncodeAsRef, HasCompact};
-use primitives::{storage::StorageKey, twox_128};
+use sp_core::{storage::StorageKey, twox_128};
 use serde::{Deserialize, Serialize};
 
 use std::{
@@ -462,12 +462,12 @@ impl<K: Encode, V: Decode + Clone> StorageMap<K, V> {
 		let mut bytes = self.prefix.clone();
 		bytes.extend(key.encode());
 		let hash = match self.hasher {
-			StorageHasher::Blake2_128 => primitives::blake2_128(&bytes).to_vec(),
-			StorageHasher::Blake2_256 => primitives::blake2_256(&bytes).to_vec(),
-			StorageHasher::Blake2_128Concat => primitives::blake2_128(&bytes).to_vec(),
-			StorageHasher::Twox128 => primitives::twox_128(&bytes).to_vec(),
-			StorageHasher::Twox256 => primitives::twox_256(&bytes).to_vec(),
-			StorageHasher::Twox64Concat => primitives::twox_64(&bytes).to_vec(),
+			StorageHasher::Blake2_128 => sp_core::blake2_128(&bytes).to_vec(),
+			StorageHasher::Blake2_256 => sp_core::blake2_256(&bytes).to_vec(),
+			StorageHasher::Blake2_128Concat => sp_core::blake2_128(&bytes).to_vec(),
+			StorageHasher::Twox128 => sp_core::twox_128(&bytes).to_vec(),
+			StorageHasher::Twox256 => sp_core::twox_256(&bytes).to_vec(),
+			StorageHasher::Twox64Concat => sp_core::twox_64(&bytes).to_vec(),
 			// TODO figure out which substrate hash function is the 'identity' function
 			StorageHasher::Identity => panic!("Unkown Hash"),
 		};

--- a/desub-legacy/src/substrate_types.rs
+++ b/desub-legacy/src/substrate_types.rs
@@ -25,8 +25,8 @@ mod remote;
 use self::remote::*;
 use crate::{Error, SetField};
 use bitvec::order::Lsb0 as BitOrderLsb0;
-use primitives::crypto::{AccountId32, Ss58Codec};
-use runtime_primitives::MultiAddress;
+use sp_core::crypto::{AccountId32, Ss58Codec};
+use sp_runtime::MultiAddress;
 use serde::Serialize;
 use std::{convert::TryFrom, fmt};
 
@@ -42,9 +42,9 @@ pub type Conviction = pallet_democracy::Conviction;
 #[serde(untagged)]
 pub enum SubstrateType {
 	/// 512-bit hash type
-	H512(primitives::H512),
+	H512(sp_core::H512),
 	/// 256-bit hash type
-	H256(primitives::H256),
+	H256(sp_core::H256),
 
 	/// BitVec type
 	BitVec(bitvec::vec::BitVec<BitOrderLsb0, u8>),
@@ -52,7 +52,7 @@ pub enum SubstrateType {
 	/// Recursive Call Type
 	Call(Vec<(String, SubstrateType)>),
 	/// Era
-	Era(runtime_primitives::generic::Era),
+	Era(sp_runtime::generic::Era),
 
 	/// Vote
 	#[serde(with = "RemoteVote")]
@@ -139,18 +139,18 @@ impl fmt::Display for SubstrateType {
 				Ok(())
 			}
 			SubstrateType::Era(v) => match v {
-				runtime_primitives::generic::Era::Mortal(s, e) => write!(f, " Era {}..{}", s, e),
-				runtime_primitives::generic::Era::Immortal => write!(f, " Immortal Era"),
+				sp_runtime::generic::Era::Mortal(s, e) => write!(f, " Era {}..{}", s, e),
+				sp_runtime::generic::Era::Immortal => write!(f, " Immortal Era"),
 			},
 			SubstrateType::GenericVote(v) => write!(f, "Aye={}, Conviction={}", v.aye, v.conviction.lock_periods()),
 			SubstrateType::Address(v) => match v {
-				runtime_primitives::MultiAddress::Id(ref i) => {
+				sp_runtime::MultiAddress::Id(ref i) => {
 					write!(f, "Account::Id({})", i.to_ss58check())
 				}
-				runtime_primitives::MultiAddress::Index(i) => write!(f, "Index: {:?}", i),
-				runtime_primitives::MultiAddress::Raw(bytes) => write!(f, "Raw: {:?}", bytes),
-				runtime_primitives::MultiAddress::Address32(ary) => write!(f, "Address32: {:?}", ary),
-				runtime_primitives::MultiAddress::Address20(ary) => write!(f, "Address20: {:?}", ary),
+				sp_runtime::MultiAddress::Index(i) => write!(f, "Index: {:?}", i),
+				sp_runtime::MultiAddress::Raw(bytes) => write!(f, "Raw: {:?}", bytes),
+				sp_runtime::MultiAddress::Address32(ary) => write!(f, "Address32: {:?}", ary),
+				sp_runtime::MultiAddress::Address20(ary) => write!(f, "Address20: {:?}", ary),
 			},
 			SubstrateType::Data(d) => write!(f, "{:?}", d),
 			SubstrateType::SignedExtra(v) => write!(f, "{}", v),

--- a/desub-legacy/src/util.rs
+++ b/desub-legacy/src/util.rs
@@ -14,7 +14,7 @@
 // along with substrate-desub.  If not, see <http://www.gnu.org/licenses/>.
 
 use crate::{Error, SubstrateType};
-use primitives::crypto::Ss58Codec;
+use sp_core::crypto::Ss58Codec;
 use serde::{
 	ser::{self, SerializeSeq},
 	Serializer,
@@ -58,18 +58,18 @@ pub fn as_substrate_address<S: Serializer>(ty: &SubstrateType, serializer: S) ->
 			for (i, b) in bytes.into_iter().enumerate() {
 				addr[i] = b;
 			}
-			let addr = primitives::crypto::AccountId32::from(addr).to_ss58check();
+			let addr = sp_core::crypto::AccountId32::from(addr).to_ss58check();
 			serializer.serialize_str(&addr)
 		}
 		SubstrateType::Address(v) => match v {
-			runtime_primitives::MultiAddress::Id(ref i) => {
+			sp_runtime::MultiAddress::Id(ref i) => {
 				let addr = i.to_ss58check();
 				serializer.serialize_str(&addr)
 			}
-			runtime_primitives::MultiAddress::Index(i) => serializer.serialize_str(&format!("{}", i)),
-			runtime_primitives::MultiAddress::Raw(bytes) => serializer.serialize_str(&format!("{:?}", bytes)),
-			runtime_primitives::MultiAddress::Address32(ary) => serializer.serialize_str(&format!("{:?}", ary)),
-			runtime_primitives::MultiAddress::Address20(ary) => serializer.serialize_str(&format!("{:?}", ary)),
+			sp_runtime::MultiAddress::Index(i) => serializer.serialize_str(&format!("{}", i)),
+			sp_runtime::MultiAddress::Raw(bytes) => serializer.serialize_str(&format!("{:?}", bytes)),
+			sp_runtime::MultiAddress::Address32(ary) => serializer.serialize_str(&format!("{:?}", ary)),
+			sp_runtime::MultiAddress::Address20(ary) => serializer.serialize_str(&format!("{:?}", ary)),
 		},
 		_ => Err(ser::Error::custom(format!("Could not format {:?} as Ss58 Address", ty))),
 	}

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -16,7 +16,6 @@ desub-json-resolver = { path = "../desub-json-resolver" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 codec = { version = "2", package = "parity-scale-codec" }
-primitives = { package = "sp-core",  git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
 frame-system = { git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
 pretty_env_logger = "0.4"
@@ -24,6 +23,8 @@ log = "0.4"
 hex = "0.4"
 paste = "1.0.3"
 anyhow = "1"
+
+sp-core = { git = "https://github.com/paritytech/substrate", tag = "monthly-2021-12" }
 
 [[test]]
 name = "integration-tests"

--- a/integration-tests/tests/metadata.rs
+++ b/integration-tests/tests/metadata.rs
@@ -1,6 +1,6 @@
 use crate::runtime_metadata::*;
 use desub_legacy::decoder::Metadata;
-use primitives::twox_128;
+use sp_core::twox_128;
 
 #[test]
 fn should_create_metadata_v9() {

--- a/integration-tests/tests/storage.rs
+++ b/integration-tests/tests/storage.rs
@@ -5,7 +5,7 @@ use desub_legacy::{
 	decoder::{Chain, Decoder, Metadata},
 	SubstrateType,
 };
-use primitives::twox_128;
+use sp_core::twox_128;
 
 /// T::BlockNumber in meta V11 Block 1768321
 fn get_plain_value() -> (Vec<u8>, Option<Vec<u8>>) {


### PR DESCRIPTION
Use actual crate names and separate git imports from other imports. Prep for vendoring.
